### PR TITLE
Image placement css 201502

### DIFF
--- a/adult-hiv/1.md
+++ b/adult-hiv/1.md
@@ -337,10 +337,10 @@ With the onset of symptomatic HIV infection (constitutional symptoms) the CD4 co
 Note
 :	A high viral set point carries a poor prognosis of rapid progression to AIDS, as it indicates failure by the immune system to control massive multiplication of HIV.
 
-![Figure 1-1: The changes in viral load, CD4 count and clinical features of HIV infection](images/fig-1-1.svg)
-
-Figure 1-1: The changes in viral load, CD4 count and clinical features of HIV infection
-{:.figure-caption}
+> ![Figure 1-1: The changes in viral load, CD4 count and clinical features of HIV infection](images/fig-1-1.svg)
+> 
+> Figure 1-1: The changes in viral load, CD4 count and clinical features of HIV infection
+{:.figure}
 
 ### 1-42 What clinical signs suggest the patient has HIV infection?
 

--- a/birth-defects/1.md
+++ b/birth-defects/1.md
@@ -133,10 +133,10 @@ A picture of the 46 chromosomes is called a karyotype. The normal female karyoty
 Note
 :	In some textbooks, 46,XY is still written as 46 XY. 46,XY is preferable.
 
-![Figure 1-1: Normal karyotype of a male (46,XY) with 23 pairs of chromosomes (22 pairs of matching autosomes and one pair of unlike sex chromosomes, X and Y)](images/.svg)
-
-Figure 1-1: Normal karyotype of a male (46,XY) with 23 pairs of chromosomes (22 pairs of matching autosomes and one pair of unlike sex chromosomes, X and Y)
-{:.figure-caption}
+> ![Figure 1-1: Normal karyotype of a male (46,XY) with 23 pairs of chromosomes (22 pairs of matching autosomes and one pair of unlike sex chromosomes, X and Y)](images/.svg)
+> 
+> Figure 1-1: Normal karyotype of a male (46,XY) with 23 pairs of chromosomes (22 pairs of matching autosomes and one pair of unlike sex chromosomes, X and Y)
+{:.figure}
 
 ### 1-9 How are chromosomes inherited?
 
@@ -153,10 +153,10 @@ Note
 
 	Cell division in which the chromosome number stays the same can also occur (asexual reproduction) and this is called mitosis. This is the type of cell reproduction that occurs to make more cells so that the zygote can multiply and develop into an embryo and fetus, and the body can grow or replace cells that die off during life.
 
-![Figure 1-2: The normal chromosome contribution of each parent](images/1-2.svg)
-
-Figure 1-2: The normal chromosome contribution of each parent
-{:.figure-caption}
+> ![Figure 1-2: The normal chromosome contribution of each parent](images/1-2.svg)
+> 
+> Figure 1-2: The normal chromosome contribution of each parent
+{:.figure}
 
 ### 1-10 What are chromosome abnormalities?
 
@@ -189,10 +189,10 @@ From an abnormal zygote with 47 chromosomes (trisomy) the fetus that develops wi
 
 > Trisomy and monosomy are caused by non-disjunction.
 
-![Figure 1-3: Non-disjunction](images/1-3.svg)
-
-Figure 1-3: Non-disjunction
-{:.figure-caption}
+> ![Figure 1-3: Non-disjunction](images/1-3.svg)
+> 
+> Figure 1-3: Non-disjunction
+{:.figure}
 
 ### 1-12 What birth defects are caused by trisomy and monosomy?
 
@@ -213,10 +213,10 @@ The only chromosome that can be lost and result in a live born infant with monos
 
 > Down syndrome, with trisomy of chromosome 21, is the commonest form of chromosomal birth defect.
 
-![Figure 1-4: The karyotype of Down syndrome in a male with an extra chromosome 21 (trisomy 21)](images/1-4.svg)
-
-Figure 1-4: The karyotype of Down syndrome in a male with an extra chromosome 21 (trisomy 21)
-{:.figure-caption}
+> ![Figure 1-4: The karyotype of Down syndrome in a male with an extra chromosome 21 (trisomy 21)](images/1-4.svg)
+> 
+> Figure 1-4: The karyotype of Down syndrome in a male with an extra chromosome 21 (trisomy 21)
+{:.figure}
 
 ### 1-13 What is mosaicism?
 
@@ -314,10 +314,10 @@ Note
 Note
 :	If both parents have the same dominant gene, there is a 75% chance (3 out of 4) that each child will inherit that gene. There is also a 25% chance (1 in 4) of the child inheriting both dominant genes, which is usually fatal if the dominant genes are abnormal. Therefore, all children will inherit either one or both dominant genes.
 
-![Figure 1-5: The pattern of autosomal dominant inheritance. There is a 50% chance that the autosomal dominant gene (e.g. D) will be passed from the affected parent to each child no matter whether a boy or girl.](images/1-5.svg)
-
-Figure 1-5: The pattern of autosomal dominant inheritance. There is a 50% chance that the autosomal dominant gene (e.g. D) will be passed from the affected parent to each child no matter whether a boy or girl.
-{:.figure-caption}
+> ![Figure 1-5: The pattern of autosomal dominant inheritance. There is a 50% chance that the autosomal dominant gene (e.g. D) will be passed from the affected parent to each child no matter whether a boy or girl.](images/1-5.svg)
+> 
+> Figure 1-5: The pattern of autosomal dominant inheritance. There is a 50% chance that the autosomal dominant gene (e.g. D) will be passed from the affected parent to each child no matter whether a boy or girl.
+{:.figure}
 
 ## Recessive inheritance
 
@@ -346,10 +346,10 @@ If only one parent is heterozygous (a carrier), the children cannot be affected 
 
 > If both parents are carriers of a recessive gene, there is a 25% chance (1 in 4) that their child will inherit both recessive genes.
 
-![Figure 1-6: The pattern of autosomal recessive inheritance. If both parents are heterozygous for a recessive gene (e.g. r), there is a 25% chance that a child will be homozygous and a 50% chance that a child will also be heterozygous for that gene.](images/1-6.svg)
-
-Figure 1-6: The pattern of autosomal recessive inheritance. If both parents are heterozygous for a recessive gene (e.g. r), there is a 25% chance that a child will be homozygous and a 50% chance that a child will also be heterozygous for that gene.
-{:.figure-caption}
+> ![Figure 1-6: The pattern of autosomal recessive inheritance. If both parents are heterozygous for a recessive gene (e.g. r), there is a 25% chance that a child will be homozygous and a 50% chance that a child will also be heterozygous for that gene.](images/1-6.svg)
+> 
+> Figure 1-6: The pattern of autosomal recessive inheritance. If both parents are heterozygous for a recessive gene (e.g. r), there is a 25% chance that a child will be homozygous and a 50% chance that a child will also be heterozygous for that gene.
+{:.figure}
 
 ### 1-24 What is X-linked recessive inheritance?
 
@@ -368,10 +368,10 @@ Note
 
 > X-linked recessive genes are carried by mothers and affect 50% of their sons.
 
-![Figure 1-7: The pattern of X-linked recessive inheritance. There is a 50% chance that the recessive gene from the mother will be inherited by both sons and daughters. Only sons will be clinically affected as the X-linked recessive gene in daughters will be paired by a normal matching gene from the father.](images/1-7.svg)
-
-Figure 1-7: The pattern of X-linked recessive inheritance. There is a 50% chance that the recessive gene from the mother will be inherited by both sons and daughters. Only sons will be clinically affected as the X-linked recessive gene in daughters will be paired by a normal matching gene from the father.
-{:.figure-caption}
+> ![Figure 1-7: The pattern of X-linked recessive inheritance. There is a 50% chance that the recessive gene from the mother will be inherited by both sons and daughters. Only sons will be clinically affected as the X-linked recessive gene in daughters will be paired by a normal matching gene from the father.](images/1-7.svg)
+> 
+> Figure 1-7: The pattern of X-linked recessive inheritance. There is a 50% chance that the recessive gene from the mother will be inherited by both sons and daughters. Only sons will be clinically affected as the X-linked recessive gene in daughters will be paired by a normal matching gene from the father.
+{:.figure}
 
 ## Single gene disorders
 

--- a/birth-defects/10.md
+++ b/birth-defects/10.md
@@ -6,77 +6,77 @@ layout: chapter
 
 # Photographs
 
-![Heterochromia: Different-coloured eyes or blue eyes in dark skinned child](images/p-1.jpg)
+> ![Heterochromia: Different-coloured eyes or blue eyes in dark skinned child](images/p-1.jpg)
+> 
+> Heterochromia: Different-coloured eyes or blue eyes in dark skinned child
+{:.figure}
 
-Heterochromia: Different-coloured eyes or blue eyes in dark skinned child
-{:.figure-caption}
+> ![Waardenburg syndrome: An infant with a white tuft of hair and wide spaced eyes](images/p-2.jpg)
+> 
+> Waardenburg syndrome: An infant with a white tuft of hair and wide spaced eyes
+{:.figure}
 
-![Waardenburg syndrome: An infant with a white tuft of hair and wide spaced eyes](images/p-2.jpg)
+> ![Haemophilia: A swollen knee due to bleeding into the joint](images/p-3.jpg)
+> 
+> Haemophilia: A swollen knee due to bleeding into the joint
+{:.figure}
 
-Waardenburg syndrome: An infant with a white tuft of hair and wide spaced eyes
-{:.figure-caption}
+> ![Viteligo: decreased skin pigmentation](images/p-4.jpg)
+> 
+> Viteligo: decreased skin pigmentation
+{:.figure}
 
-![Haemophilia: A swollen knee due to bleeding into the joint](images/p-3.jpg)
+> ![Oculocutaneous albinism](images/p-5.jpg)
+> 
+> Oculocutaneous albinism
+{:.figure}
 
-Haemophilia: A swollen knee due to bleeding into the joint
-{:.figure-caption}
+> ![Down syndrome: The eyes slant upwards, the bridge of the nose is flat, and the tongue may protrude](images/p-6.jpg)
+> 
+> Down syndrome: The eyes slant upwards, the bridge of the nose is flat, and the tongue may protrude
+{:.figure}
 
-![Viteligo: decreased skin pigmentation](images/p-4.jpg)
+> ![Amputated fingers in amniotic band syndrome](images/p-7.jpg)
+> 
+> Amputated fingers in amniotic band syndrome
+{:.figure}
 
-Viteligo: decreased skin pigmentation
-{:.figure-caption}
+> ![Single transverse palmar crease](images/p-8.jpg)
+> 
+> Single transverse palmar crease
+{:.figure}
 
-![Oculocutaneous albinism](images/p-5.jpg)
+> ![Bilateral cleft lip and palate](images/p-9.jpg)
+> 
+> Bilateral cleft lip and palate
+{:.figure}
 
-Oculocutaneous albinism
-{:.figure-caption}
+> ![Isolated cleft palate](images/p-10.jpg)
+> 
+> Isolated cleft palate
+{:.figure}
 
-![Down syndrome: The eyes slant upwards, the bridge of the nose is flat, and the tongue may protrude](images/p-6.jpg)
+> ![Club-foot](images/p-11.jpg)
+> 
+> Club-foot
+{:.figure}
 
-Down syndrome: The eyes slant upwards, the bridge of the nose is flat, and the tongue may protrude
-{:.figure-caption}
+> ![Infant with fetal alcohol syndrome: long smooth upper lip](images/p-12.jpg)
+> 
+> Infant with fetal alcohol syndrome: long smooth upper lip
+{:.figure}
 
-![Amputated fingers in amniotic band syndrome](images/p-7.jpg)
+> ![A fetus with anencephaly exposing the brain](images/p-13.jpg)
+> 
+> A fetus with anencephaly exposing the brain
+{:.figure}
 
-Amputated fingers in amniotic band syndrome
-{:.figure-caption}
+> ![Severe lumbosacral meningomyelocoele with neural tissue exposed](images/p-14.jpg)
+> 
+> Severe lumbosacral meningomyelocoele with neural tissue exposed
+{:.figure}
 
-![Single transverse palmar crease](images/p-8.jpg)
-
-Single transverse palmar crease
-{:.figure-caption}
-
-![Bilateral cleft lip and palate](images/p-9.jpg)
-
-Bilateral cleft lip and palate
-{:.figure-caption}
-
-![Isolated cleft palate](images/p-10.jpg)
-
-Isolated cleft palate
-{:.figure-caption}
-
-![Club-foot](images/p-11.jpg)
-
-Club-foot
-{:.figure-caption}
-
-![Infant with fetal alcohol syndrome: long smooth upper lip](images/p-12.jpg)
-
-Infant with fetal alcohol syndrome: long smooth upper lip
-{:.figure-caption}
-
-![A fetus with anencephaly exposing the brain](images/p-13.jpg)
-
-A fetus with anencephaly exposing the brain
-{:.figure-caption}
-
-![Severe lumbosacral meningomyelocoele with neural tissue exposed](images/p-14.jpg)
-
-Severe lumbosacral meningomyelocoele with neural tissue exposed
-{:.figure-caption}
-
-![Severe meningomyelocoele with a thin membrane covering the defect](images/p-15.jpg)
-
-Severe meningomyelocoele with a thin membrane covering the defect
-{:.figure-caption}
+> ![Severe meningomyelocoele with a thin membrane covering the defect](images/p-15.jpg)
+> 
+> Severe meningomyelocoele with a thin membrane covering the defect
+{:.figure}

--- a/birth-defects/2.md
+++ b/birth-defects/2.md
@@ -97,10 +97,10 @@ The following symbols are used in a three-generation family tree:
 
 Parents are linked to each other with a horizontal line (marriage or partnership line), while parents and children are linked with a vertical line (descent line). Two parallel lines link parents who are related (consanguineous).
 
-![Figure 2-1: A family tree of a female child with a birth defect, whose carrier parents are unaffected but consanguineous. The affected child’s grandparents and great grandfather are also carriers of the abnormal autosomal recessive gene that caused her disorder.](images/2-1.svg)
-
-Figure 2-1: A family tree of a female child with a birth defect, whose carrier parents are unaffected but consanguineous. The affected child’s grandparents and great grandfather are also carriers of the abnormal autosomal recessive gene that caused her disorder.
-{:.figure-caption}
+> ![Figure 2-1: A family tree of a female child with a birth defect, whose carrier parents are unaffected but consanguineous. The affected child’s grandparents and great grandfather are also carriers of the abnormal autosomal recessive gene that caused her disorder.](images/2-1.svg)
+> 
+> Figure 2-1: A family tree of a female child with a birth defect, whose carrier parents are unaffected but consanguineous. The affected child’s grandparents and great grandfather are also carriers of the abnormal autosomal recessive gene that caused her disorder.
+{:.figure}
 
 ### 2-6 What is a genetic diagnosis?
 
@@ -248,10 +248,10 @@ This counselling will offer them two choices:
 
 2.	To continue the pregnancy without prenatal diagnosis: A pregnant woman may decide to take this choice, knowing and understanding the risks of having an infant with a birth defect.
 
-![Figure 2-2: Amniocentesis to obtain a sample of amniotic fluid.](images/2-2.svg)
-
-Figure 2-2: Amniocentesis to obtain a sample of amniotic fluid.
-{:.figure-caption}
+> ![Figure 2-2: Amniocentesis to obtain a sample of amniotic fluid.](images/2-2.svg)
+> 
+> Figure 2-2: Amniocentesis to obtain a sample of amniotic fluid.
+{:.figure}
 
 ## Parents’ choices with prenatal diagnosis
 

--- a/birth-defects/3.md
+++ b/birth-defects/3.md
@@ -202,10 +202,10 @@ In the other 2% of infants with Down syndrome, only some of their body cells hav
 
 The appearance of children with Down syndrome is the same whether the extra chromosome 21 material is due to trisomy, translocation or mosaicism.
 
-![Figure 3-1: The appearance of the chromosomes in trisomy 21 (karyotype). Note that there are three instead of the normal two chromosomes 21.](images/3-1.svg)
-
-Figure 3-1: The appearance of the chromosomes in trisomy 21 (karyotype). Note that there are three instead of the normal two chromosomes 21.
-{:.figure-caption}
+> ![Figure 3-1: The appearance of the chromosomes in trisomy 21 (karyotype). Note that there are three instead of the normal two chromosomes 21.](images/3-1.svg)
+> 
+> Figure 3-1: The appearance of the chromosomes in trisomy 21 (karyotype). Note that there are three instead of the normal two chromosomes 21.
+{:.figure}
 
 ### 3-7 How does trisomy 21 occur?
 
@@ -214,10 +214,10 @@ Trisomy 21 (having an extra chromosome 21) is caused by non-disjunction. This is
 Note
 :	Down syndrome usually occurs because of non-disjunction in the ovum of the mother (80%). However, in 20% of people with Down syndrome the non-disjunction takes place in the father, and it is the sperm that has the extra chromosome 21.
 
-![Figure 3-2: Non disjunction to give trisomy 21](images/3-2.svg)
-
-Figure 3-2: Non disjunction to give trisomy 21
-{:.figure-caption}
+> ![Figure 3-2: Non disjunction to give trisomy 21](images/3-2.svg)
+> 
+> Figure 3-2: Non disjunction to give trisomy 21
+{:.figure}
 
 ### 3-8 How can one recognise a person with Down syndrome?
 

--- a/birth-defects/5.md
+++ b/birth-defects/5.md
@@ -165,10 +165,10 @@ Normally, one drink results in a blood alcohol concentration in the range of 20â
 
 > Drinking a lot of alcohol fast results in a high blood alcohol concentration.
 
-![Figure 5-1: The blood alcohol concentration over eight hours after one to four drinks. The greater the number of drinks, the higher the peak blood alcohol concentration and the longer it takes to return to nil.](images/5-1.svg)
-
-Figure 5-1: The blood alcohol concentration over eight hours after one to four drinks. The greater the number of drinks, the higher the peak blood alcohol concentration and the longer it takes to return to nil.
-{:.figure-caption}
+> ![Figure 5-1: The blood alcohol concentration over eight hours after one to four drinks. The greater the number of drinks, the higher the peak blood alcohol concentration and the longer it takes to return to nil.](images/5-1.svg)
+> 
+> Figure 5-1: The blood alcohol concentration over eight hours after one to four drinks. The greater the number of drinks, the higher the peak blood alcohol concentration and the longer it takes to return to nil.
+{:.figure}
 
 ### 5-18 How does maternal weight affect the blood alcohol concentration?
 
@@ -225,10 +225,10 @@ Fetal alcohol syndrome should always be expected if the mother gives a history o
 
 If the doctor is not sure whether the infant has fetal alcohol syndrome, the infantâ€™s growth and development should be monitored before confirming the diagnosis. It is important to be sure of the diagnosis before labelling an infant as having fetal alcohol syndrome. It is therefore important to refer the infant for further follow-up, e.g. developmental assessment at a later stage.
 
-![Figure 5-2: The typical facial features of fetal alcohol syndrome](images/5-2.svg)
-
-Figure 5-2: The typical facial features of fetal alcohol syndrome
-{:.figure-caption}
+> ![Figure 5-2: The typical facial features of fetal alcohol syndrome](images/5-2.svg)
+> 
+> Figure 5-2: The typical facial features of fetal alcohol syndrome
+{:.figure}
 
 ### 5-26 At what age is it easiest to diagnose fetal alcohol syndrome?
 

--- a/birth-defects/6.md
+++ b/birth-defects/6.md
@@ -39,10 +39,10 @@ Neural tube defects are typical examples of a **multifactorial congenital malfor
 
 At 22 days after conception, the embryo is a flat, pear-shaped plate made up of three layers of cells. By a process of folding in the midline, the top layer of cells forms a tube within the middle layer of the plate. This tube, the neural tube, runs from top to bottom of the developing embryo and is formed by 28 days post conception.
 
-![Figure 6-1: The three layers of the embryonic plate showing the folding to form the neural tube](images/6-1.svg)
-
-Figure 6-1: The three layers of the embryonic plate showing the folding to form the neural tube
-{:.figure-caption}
+> ![Figure 6-1: The three layers of the embryonic plate showing the folding to form the neural tube](images/6-1.svg)
+> 
+> Figure 6-1: The three layers of the embryonic plate showing the folding to form the neural tube
+{:.figure}
 
 ### 6-3 What develops from the neural tube?
 
@@ -75,20 +75,20 @@ Spina bifida may be either open or closed, depending on the type.
 Note
 :	Meningomyelocoele (or myelomeningocoele) is also referred to as spina bifida cystica while meningocoele is also called spina bifida aperta. Cystica is Latin for cyst and aperta means an opening.
 
-![Figure 6-2: A cross section of the spinal column showing a meningmyelocoele with both the spinal cord and meninges protruding through a defect in the vertebral arches.](images/6-2.svg)
+> ![Figure 6-2: A cross section of the spinal column showing a meningmyelocoele with both the spinal cord and meninges protruding through a defect in the vertebral arches.](images/6-2.svg)
+> 
+> Figure 6-2: A cross section of the spinal column showing a meningmyelocoele with both the spinal cord and meninges protruding through a defect in the vertebral arches.
+{:.figure}
 
-Figure 6-2: A cross section of the spinal column showing a meningmyelocoele with both the spinal cord and meninges protruding through a defect in the vertebral arches.
-{:.figure-caption}
+> ![Figure 6-3: A cross section of the spinal column showing a meningocoele with only the meninges protruding through a defect in the vertebral arches](images/6-3.svg)
+> 
+> Figure 6-3: A cross section of the spinal column showing a meningocoele with only the meninges protruding through a defect in the vertebral arches
+{:.figure}
 
-![Figure 6-3: A cross section of the spinal column showing a meningocoele with only the meninges protruding through a defect in the vertebral arches](images/6-3.svg)
-
-Figure 6-3: A cross section of the spinal column showing a meningocoele with only the meninges protruding through a defect in the vertebral arches
-{:.figure-caption}
-
-![Figure 6-4: A cross section of the spinal column showing spina bifida occulta with neither the spinal cord nor the meninges protruding through a defect in the vertebral arches](images/6-4.svg)
-
-Figure 6-4: A cross section of the spinal column showing spina bifida occulta with neither the spinal cord nor the meninges protruding through a defect in the vertebral arches
-{:.figure-caption}
+> ![Figure 6-4: A cross section of the spinal column showing spina bifida occulta with neither the spinal cord nor the meninges protruding through a defect in the vertebral arches](images/6-4.svg)
+> 
+> Figure 6-4: A cross section of the spinal column showing spina bifida occulta with neither the spinal cord nor the meninges protruding through a defect in the vertebral arches
+{:.figure}
 
 ### 6-7 What is a meningomyelocoele?
 

--- a/breast-care/0-5-preface.md
+++ b/breast-care/0-5-preface.md
@@ -18,4 +18,4 @@ We have had great fun writing the book. As can be seen from the page of acknowle
 
 *Prof David Woods* is a retired neonatologist in Cape Town and the editor-in-chief of the renowned Perinatal Education Programme. He is passionate about self-empowered distant learning for all health professionals.
 
-![Breast Course 4 Nurses](images/breast-course-4-nurses-logo.jpg){:.quarter-page}
+![Breast Course 4 Nurses](images/breast-course-4-nurses-logo.jpg){:.titlepage-logo}

--- a/breast-care/1.md
+++ b/breast-care/1.md
@@ -56,10 +56,10 @@ Usually one breast is present on either side of the chest. However, one or more 
 Note
 :	Breasts or mammary glands are present in all mammals.
 
-![Figure 1-1: The breast line](images/fig-1-1.svg)
-
-Figure 1-1: The breast line
-{:.figure-caption}
+> ![Figure 1-1: The breast line](images/fig-1-1.svg)
+> 
+> Figure 1-1: The breast line
+{:.figure}
 
 ### 1-2 What are breasts normally like at birth?
 
@@ -98,10 +98,10 @@ More than 50% of women have one breast that appears slightly larger than the oth
 
 The breasts may continue to enlarge and start to droop even if the woman is not pregnant. This change in breast size and shape is normal.
 
-![Figure 1-2: The normal stages of breast development](images/fig-1-2.svg)
-
-Figure 1-2: The normal stages of breast development
-{:.figure-caption}
+> ![Figure 1-2: The normal stages of breast development](images/fig-1-2.svg)
+> 
+> Figure 1-2: The normal stages of breast development
+{:.figure}
 
 ## Normal breast anatomy
 
@@ -109,10 +109,10 @@ Figure 1-2: The normal stages of breast development
 
 The breast is shaped like a pear and the tail of breast tissue extends under the arm. Some women have breast tissue that can be felt in the armpit. This may be more noticeable during pregnancy.
 
-![Figure 1-3: The shape of the normal breast](images/fig-1-3.svg)
-
-Figure 1-3: The shape of the normal breast
-{:.figure-caption}
+> ![Figure 1-3: The shape of the normal breast](images/fig-1-3.svg)
+> 
+> Figure 1-3: The shape of the normal breast
+{:.figure}
 
 ### 1-10 What is the structure of the normal breast?
 
@@ -123,10 +123,10 @@ The breast consists of:
 *	About 10 or more lobes
 *	Supportive and fatty tissue
 
-![Figure 1-4: The normal structures of the adult breast](images/fig-1-4.svg)
-
-Figure 1-4: The normal structures of the adult breast
-{:.figure-caption}
+> ![Figure 1-4: The normal structures of the adult breast](images/fig-1-4.svg)
+> 
+> Figure 1-4: The normal structures of the adult breast
+{:.figure}
 
 ### 1-11 What is the appearance of a normal nipple and areola?
 
@@ -137,19 +137,19 @@ Note
 
 > The nipple-areola complex (NAC) is made up of both the nipple and surrounding areola.
 
-![Figure 1-5: The appearance of the normal nipple-areola complex](images/fig-1-5.svg)
-
-Figure 1-5: The appearance of the normal nipple-areola complex
-{:.figure-caption}
+> ![Figure 1-5: The appearance of the normal nipple-areola complex](images/fig-1-5.svg)
+> 
+> Figure 1-5: The appearance of the normal nipple-areola complex
+{:.figure}
 
 ### 1-12 What is the function of the lobes?
 
 The lobes (made up of many lobules) are glandular structures. The major lobes drain into ducts which open onto the nipple. During pregnancy (and in newborn infants) the lobes produce milk.
 
-![](Figure 1-6: The lobes draining into ducts opening onto the nippleimages/fig-1-6.svg)
-
-Figure 1-6: The lobes draining into ducts opening onto the nipple
-{:.figure-caption}
+> ![Figure 1-6: The lobes draining into ducts opening onto the nipple](images/fig-1-6.svg)
+> 
+> Figure 1-6: The lobes draining into ducts opening onto the nipple
+{:.figure}
 
 ### 1-13 Why is the supportive and fatty tissue in the breast important?
 
@@ -245,15 +245,15 @@ It is very important to make a correct diagnosis of fibroadenoma as it may feel 
 
 > The correct diagnosis of a fibroadenoma is important as a breast cancer can feel like a fibroadenoma.
 
-![Figure 1-7: The appearance of a fibroadenoma](images/fig-1-7.svg)
+> ![Figure 1-7: The appearance of a fibroadenoma](images/fig-1-7.svg)
+> 
+> Figure 1-7: The appearance of a fibroadenoma
+{:.figure}
 
-Figure 1-7: The appearance of a fibroadenoma
-{:.figure-caption}
-
-![Figure 1-8: The nodular appearance of a fibroadenoma. Benign lumps (such as fibroadenomas) lie within normal breast tissue.](images/fig-1-8.svg)
-
-Figure 1-8: The nodular appearance of a fibroadenoma. Benign lumps (such as fibroadenomas) lie within normal breast tissue.
-{:.figure-caption}
+> ![Figure 1-8: The nodular appearance of a fibroadenoma. Benign lumps (such as fibroadenomas) lie within normal breast tissue.](images/fig-1-8.svg)
+> 
+> Figure 1-8: The nodular appearance of a fibroadenoma. Benign lumps (such as fibroadenomas) lie within normal breast tissue.
+{:.figure}
 
 ### 1-24 When are breasts considered too large?
 
@@ -277,10 +277,10 @@ The commonest normal change is breast pain (mastalgia) which is usually worse in
 
 Fluid-filled cysts are common in women between 35 and 55 years old. They usually occur before menopause and are rare after menopause. They may be painful or tender especially before the periods. They feel smooth. Often there is more than one cyst.
 
-![Figure 1-9: Breast with cyst](images/fig-1-9.svg)
-
-Figure 1-9: Breast with cyst
-{:.figure-caption}
+> ![Figure 1-9: Breast with cyst](images/fig-1-9.svg)
+> 
+> Figure 1-9: Breast with cyst
+{:.figure}
 
 ### 1-29 What is duct ectasia and when does it occur?
 

--- a/breast-care/15-examination-form.md
+++ b/breast-care/15-examination-form.md
@@ -80,4 +80,4 @@ layout: chapter
   </tbody>
 </table>
 
-![Exam form diagram](images/fig-15-1.svg){:.quarter-page}
+![Exam form diagram](images/fig-15-1.svg)

--- a/breast-care/2.md
+++ b/breast-care/2.md
@@ -98,10 +98,10 @@ The lifetime risk of breast cancer is 1 in 9 in a woman who lives to the age of 
 
 > The lifetime risk of breast cancer is 1 in 9 if a woman lives to 80.
 
-![Figure 2-1: The age of women at breast cancer diagnosis (data from the United Kingdom)](images/fig-2-1.svg)
-
-Figure 2-1: The age of women at breast cancer diagnosis (data from the United Kingdom)
-{:.figure-caption}
+> ![Figure 2-1: The age of women at breast cancer diagnosis (data from the United Kingdom)](images/fig-2-1.svg)
+> 
+> Figure 2-1: The age of women at breast cancer diagnosis (data from the United Kingdom)
+{:.figure}
 
 ### 2-5 What is the importance of a family history when assessing the risk of breast cancer?
 
@@ -254,61 +254,61 @@ The examination consists of both looking (inspection) and feeling (palpating). W
 
 1.	Sit the patient down on the examining couch and *look* at her breasts with her arms relaxed. Look for breast asymmetry, nipple inversion, skin changes and redness.
 
-	![Figure 2-2: Position during inspection of breasts](images/fig-2-1.svg)
-
-	Figure 2-2: Position during inspection of breasts
-	{:.figure-caption}
+	> ![Figure 2-2: Position during inspection of breasts](images/fig-2-1.svg)
+	> 
+	> Figure 2-2: Position during inspection of breasts
+	{:.figure .fixed}
 
 2.	Ask the patient to raise her arms above the head. Look for any skin puckering. Ask the patient to point out where the problem is. Look specifically in that area to see if there is any change in the skin while she is moving her arm. This will help identify if a lump is attached to the skin.
 	
-	![Figure 2-3: Position with arms raised while looking for a lump or skin puckering.](images/fig-2-3.svg)
-
-	Figure 2-3: Position with arms raised while looking for a lump or skin puckering.
-	{:.figure-caption}
+	> ![Figure 2-3: Position with arms raised while looking for a lump or skin puckering.](images/fig-2-3.svg)
+	> 
+	> Figure 2-3: Position with arms raised while looking for a lump or skin puckering.
+	{:.figure .fixed}
 
 3.	Ask the patient to put her hands on her hips and squeeze. Look and see if the area over the lump changes. This will show whether a lump is attached (tethered) to underlying muscle.
 
-	![Figure 2-4: Position with hands on hips while looking for tethering to underlying muscle.](images/fig-2-4.svg)
-
-	Figure 2-4: Position with hands on hips while looking for tethering to underlying muscle.
-	{:.figure-caption}
+	> ![Figure 2-4: Position with hands on hips while looking for tethering to underlying muscle.](images/fig-2-4.svg)
+	> 
+	> Figure 2-4: Position with hands on hips while looking for tethering to underlying muscle.
+	{:.figure .fixed}
 
 	> The breasts should be examined from the front with the patient sitting and relaxed, then with the arms raised and finally with the hands pressing on the hips.
 
 4.	Feel in the area above the clavicle (collar bone) for any lumps in the neck.
 
-	![Figure 2-5: Position for supraclavicular node examination](images/fig-2-5.svg)
-
-	Figure 2-5: Position for supraclavicular node examination
-	{:.figure-caption}
+	> ![Figure 2-5: Position for supraclavicular node examination](images/fig-2-5.svg)
+	> 
+	> Figure 2-5: Position for supraclavicular node examination
+	{:.figure .fixed}
 
 5.	To examine the armpits properly the patient must be relaxed. If the patient is very ticklish it helps to press more firmly. The best way to get the patient to relax her muscles is by asking her to extend her arms and rest them on your shoulders while you examine the armpits. Feel in the two armpits (axillae) at the same time for any lumps. This allows you to compare the two armpits. The armpits are shaped like pyramids. You should feel along the inside wall and towards the front (anterior) for lymph nodes. Remember to feel at the top of the armpit also. If you think you feel a lump, examine that armpit very carefully. If you think you can feel a lump in one armpit it is best to examine that side alone. Palpating the armpits is an essential part of breast examination.
 	
-	![Figure 2-6: Position while feeling in the armpits for nodes](images/fig-2-6.svg)
-
-	Figure 2-6: Position while feeling in the armpits for nodes
-	{:.figure-caption}
+	> ![Figure 2-6: Position while feeling in the armpits for nodes](images/fig-2-6.svg)
+	> 
+	> Figure 2-6: Position while feeling in the armpits for nodes
+	{:.figure .fixed}
 
 	> To examine the armpits properly the patient must be relaxed.
 
 6.	Finally lie the patient down flat on her back and palpate (feel) her breasts with her arms above her head. This will flatten the breasts and make examination easier. It is easier to think of the breasts being divided into strips and then palpate each breast from the centre of the chest outwards. The breast extends from the clavicle (collarbone) above to the 6th rib below. The whole area of the breast must be examined. Always use the pulps of your fingers (the most sensitive part of your hand) with the rest of your hand gently resting against the breast. Do not use cold hands.
 
-	![Figure 2-7: The breast is palpated in strips to make sure the whole breast is examined.](images/fig-2-7.svg)
-
-	Figure 2-7: The breast is palpated in strips to make sure the whole breast is examined.
-	{:.figure-caption}
+	> ![Figure 2-7: The breast is palpated in strips to make sure the whole breast is examined.](images/fig-2-7.svg)
+	> 
+	> Figure 2-7: The breast is palpated in strips to make sure the whole breast is examined.
+	{:.figure .fixed}
 	
-	![Figure 2-8: The breast being examined using finger tips with a flat hand.](images/fig-2-8.svg)
-
-	Figure 2-8: The breast being examined using finger tips with a flat hand.
-	{:.figure-caption}
+	> ![Figure 2-8: The breast being examined using finger tips with a flat hand.](images/fig-2-8.svg)
+	> 
+	> Figure 2-8: The breast being examined using finger tips with a flat hand.
+	{:.figure}
 
 7.	Never forget to examine behind the nipple-areola complex (NAC) for any abnormalities such as skin changes, lumps or an inverted nipple. It is best to leave the nipple examination to the end once you have won the woman’s trust.
 
-	![Figure 2-9: Examining the nipple and areola for skin changes and lumps.](images/fig-2-9.svg)
-
-	Figure 2-9: Examining the nipple and areola for skin changes and lumps.
-	{:.figure-caption}
+	> ![Figure 2-9: Examining the nipple and areola for skin changes and lumps.](images/fig-2-9.svg)
+	> 
+	> Figure 2-9: Examining the nipple and areola for skin changes and lumps.
+	{:.figure .fixed}
 
 ### 2-24 What do you look for when examining the breast?
 

--- a/breast-care/3.md
+++ b/breast-care/3.md
@@ -88,10 +88,10 @@ All three investigations should agree for the diagnosis to be accepted. An accur
 
 A mammogram is a radiological investigation (mammography) in which the breast is compressed and then X-rayed. The underlying breast tissue is seen and abnormalities may be detected. A mass is an abnormal area, which may have the appearance of being cancerous (malignant) or non-cancerous (benign). 
 
-![Figure 3-1: Normal breasts shown on a mammogram. Ducts and glandular tissue appear whitish while fat appears black.](images/fig-3-1.svg)
-
-Figure 3-1: Normal breasts shown on a mammogram. Ducts and glandular tissue appear whitish while fat appears black.
-{:.figure-caption}
+> ![Figure 3-1: Normal breasts shown on a mammogram. Ducts and glandular tissue appear whitish while fat appears black.](images/fig-3-1.svg)
+> 
+> Figure 3-1: Normal breasts shown on a mammogram. Ducts and glandular tissue appear whitish while fat appears black.
+{:.figure}
 
 ### 3-5 What is an ultrasound scan?
 
@@ -157,15 +157,15 @@ A mammogram may be normal or may show:
 
 > 15% of breast cancers do not show up on a mammogram.
 
-![Figure 3-2: The cancer appears white and irregular (spiculated) against the black background.](images/fig-3-2.svg)
+> ![Figure 3-2: The cancer appears white and irregular (spiculated) against the black background.](images/fig-3-2.svg)
+> 
+> Figure 3-2: The cancer appears white and irregular (spiculated) against the black background.
+{:.figure}
 
-Figure 3-2: The cancer appears white and irregular (spiculated) against the black background.
-{:.figure-caption}
-
-![Figure 3-3: Typical microcalcifications associated with a cancer](images/fig-3-3.svg)
-
-Figure 3-3: Typical microcalcifications associated with a cancer
-{:.figure-caption}
+> ![Figure 3-3: Typical microcalcifications associated with a cancer](images/fig-3-3.svg)
+> 
+> Figure 3-3: Typical microcalcifications associated with a cancer
+{:.figure}
 
 ### 3-14 Is a mammogram painful?
 
@@ -229,20 +229,20 @@ An ultrasound scan is good at showing the difference between a cyst and a solid 
 
 > An ultrasound scan is good at showing the difference between a cyst and a solid lump.
 
-![Figure 3-4: Typical appearance of an invasive cancer on an ultrasound scan. The outline of the mass is irregular with no clear margins.](images/fig-3-4.svg)
+> ![Figure 3-4: Typical appearance of an invasive cancer on an ultrasound scan. The outline of the mass is irregular with no clear margins.](images/fig-3-4.svg)
+> 
+> Figure 3-4: Typical appearance of an invasive cancer on an ultrasound scan. The outline of the mass is irregular with no clear margins.
+{:.figure}
 
-Figure 3-4: Typical appearance of an invasive cancer on an ultrasound scan. The outline of the mass is irregular with no clear margins.
-{:.figure-caption}
+> ![Figure 3-5: A simple cyst on an ultrasound scan. The cyst has a smooth outline.](images/fig-3-5.svg)
+> 
+> Figure 3-5: A simple cyst on an ultrasound scan. The cyst has a smooth outline.
+{:.figure}
 
-![Figure 3-5: A simple cyst on an ultrasound scan. The cyst has a smooth outline.](images/fig-3-5.svg)
-
-Figure 3-5: A simple cyst on an ultrasound scan. The cyst has a smooth outline.
-{:.figure-caption}
-
-![Figure 3-6: The appearance of a fi broadenoma on an ultrasound scan. It typically has clear margins and compresses the tissue around it. Note nodular appearance.](images/fig-3-6.svg)
-
-Figure 3-6: The appearance of a fi broadenoma on an ultrasound scan. It typically has clear margins and compresses the tissue around it. Note nodular appearance.
-{:.figure-caption}
+> ![Figure 3-6: The appearance of a fi broadenoma on an ultrasound scan. It typically has clear margins and compresses the tissue around it. Note nodular appearance.](images/fig-3-6.svg)
+> 
+> Figure 3-6: The appearance of a fi broadenoma on an ultrasound scan. It typically has clear margins and compresses the tissue around it. Note nodular appearance.
+{:.figure}
 
 ### 3-22 How can a lump seen on an ultrasound be investigated?
 
@@ -268,10 +268,10 @@ Cytology is the examination of cells obtained from an aspirate (something which 
 
 A fine needle aspiration (FNA) can be performed. This involves using a thin 22G needle and a 10 ml syringe. The needle is passed into the mass (lump or cyst) and cells or fluid are aspirated. Usually the lump is sampled a number of times in slightly different places (multiple passes). The aspirate is placed on a number of glass slides, which are then sprayed with a fixative solution (as with a Pap smear). The slides are sent for examination.
 
-![Figure 3-7: Fine needle aspiration. The needle is inserted into the lump. Suction is used to extract fluid/cells.](images/fig-3-7.svg)
-
-Figure 3-7: Fine needle aspiration. The needle is inserted into the lump. Suction is used to extract fluid/cells.
-{:.figure-caption}
+> ![Figure 3-7: Fine needle aspiration. The needle is inserted into the lump. Suction is used to extract fluid/cells.](images/fig-3-7.svg)
+> 
+> Figure 3-7: Fine needle aspiration. The needle is inserted into the lump. Suction is used to extract fluid/cells.
+{:.figure}
 
 ### 3-26 What results can cytology give?
 
@@ -281,10 +281,10 @@ Figure 3-7: Fine needle aspiration. The needle is inserted into the lump. Suctio
 *	*Suspicious*: the lump is probably a cancer but the diagnosis cannot be made for certain.
 *	*Malignant*: the lump is definitely malignant.
 
-![Figure 3-8: Normal and malignant cells on cytology](images/fig-3-8.svg)
-
-Figure 3-8: Normal and malignant cells on cytology
-{:.figure-caption}
+> ![Figure 3-8: Normal and malignant cells on cytology](images/fig-3-8.svg)
+> 
+> Figure 3-8: Normal and malignant cells on cytology
+{:.figure}
 
 ### 3-27 What do breast cells look like? 
 
@@ -344,10 +344,10 @@ The large needle is introduced through a small cut made in the skin with a scalp
 
 A radiologist or a breast specialist usually does the core biopsy.
 
-![Figure 3-9: A core biopsy (Tru-cut) needle being introduced into the breast.](images/fig-.svg)
-
-Figure 3-9: A core biopsy (Tru-cut) needle being introduced into the breast.
-{:.figure-caption}
+> ![Figure 3-9: A core biopsy (Tru-cut) needle being introduced into the breast.](images/fig-.svg)
+> 
+> Figure 3-9: A core biopsy (Tru-cut) needle being introduced into the breast.
+{:.figure}
 
 ### 3-34 How accurate is histology?
 

--- a/breast-care/4.md
+++ b/breast-care/4.md
@@ -110,10 +110,10 @@ However, it is always possible that the lump may be malignant.
 
 The woman may have one fibro­adenoma or many fibroadenomas (fibroadenomata). A fibroadenoma consists of both fibrous and glandular tissue.
 
-![Figure 4-1: Drawing of ultrasound view of a typical fibroadenoma. Note the normal tissue flowing past the lump and the white line under the lump.](images/fig-4-1.svg)
-
-Figure 4-1: Drawing of ultrasound view of a typical fibroadenoma. Note the normal tissue flowing past the lump and the white line under the lump.
-{:.figure-caption}
+> ![Figure 4-1: Drawing of ultrasound view of a typical fibroadenoma. Note the normal tissue flowing past the lump and the white line under the lump.](images/fig-4-1.svg)
+> 
+> Figure 4-1: Drawing of ultrasound view of a typical fibroadenoma. Note the normal tissue flowing past the lump and the white line under the lump.
+{:.figure}
 
 ### 4-9 Who usually gets fibroadenomas?
 
@@ -174,10 +174,10 @@ There may be microcysts (very small cycts) or macrocysts (larger cysts). Macrocy
 
 The cysts may not be distended with fluid in which case they are soft. A cyst is like a balloon. The more it is filled up, the more it is palpable. If it is only partially filled, it may not be palpable as it is soft. Therefore it is possible to have large cysts that cannot be felt.
 
-![Figure 4-2: A drawing of an ultrasound scan of a cyst showing the typical black appearance. Note the white line underneath and the normal tissue flowing over the lump. The fluid removed from the cyst is typically greenish and is sometimes thick.](images/fig-4-2.svg)
-
-Figure 4-2: A drawing of an ultrasound scan of a cyst showing the typical black appearance. Note the white line underneath and the normal tissue flowing over the lump. The fluid removed from the cyst is typically greenish and is sometimes thick.
-{:.figure-caption}
+> ![Figure 4-2: A drawing of an ultrasound scan of a cyst showing the typical black appearance. Note the white line underneath and the normal tissue flowing over the lump. The fluid removed from the cyst is typically greenish and is sometimes thick.](images/fig-4-2.svg)
+> 
+> Figure 4-2: A drawing of an ultrasound scan of a cyst showing the typical black appearance. Note the white line underneath and the normal tissue flowing over the lump. The fluid removed from the cyst is typically greenish and is sometimes thick.
+{:.figure}
 
 ### 4-18 What causes cysts?
 
@@ -415,10 +415,10 @@ An intraductal papilloma is a growth in a duct. The closer the growth is to the 
 
 An intraductal papilloma generally presents with bleeding from a single duct.
 
-![Figure 4-3: Intraductal papilloma](images/fig-4-3.svg)
-
-Figure 4-3: Intraductal papilloma
-{:.figure-caption}
+> ![Figure 4-3: Intraductal papilloma](images/fig-4-3.svg)
+> 
+> Figure 4-3: Intraductal papilloma
+{:.figure}
 
 ## Infections of the breast
 

--- a/breast-care/5.md
+++ b/breast-care/5.md
@@ -93,10 +93,10 @@ Ductal carcinoma in situ will progress to invasive cancer over time as the malig
 
 Lobular carcinoma in situ (LCIS) is very complicated and far less common. If LCIS is found anywhere in either breast, it means the woman is more likely to develop a breast cancer at some stage in her life although it may not actually be in the same place where the LCIS has formed.
 
-![Figure 5-1: Stages from normal duct to invasive ductal cancer](images/fig-5-1.svg)
-
-Figure 5-1: Stages from normal duct to invasive ductal cancer
-{:.figure-caption}
+> ![Figure 5-1: Stages from normal duct to invasive ductal cancer](images/fig-5-1.svg)
+> 
+> Figure 5-1: Stages from normal duct to invasive ductal cancer
+{:.figure}
 
 ### 5-5 Are there any non-cancerous conditions associated with an increased risk of breast cancer?
 
@@ -137,24 +137,24 @@ Breast cancer can spread via the lymphatic system to the local lymph nodes and a
 
 If the breast cancer cells are spread via the blood stream, they will follow the blood flow from the breast to the next organ or be trapped where the blood vessels become narrow. In practice, this means the lungs, liver, bone or brain. Cancer cells may go to the brain.
 
-![Figure 5-2: Lymphatic breast drainage to axillary and internal mammary nodes.](images/fig-5-2.svg)
+> ![Figure 5-2: Lymphatic breast drainage to axillary and internal mammary nodes.](images/fig-5-2.svg)
+> 
+> Figure 5-2: Lymphatic breast drainage to axillary and internal mammary nodes.
+{:.figure}
 
-Figure 5-2: Lymphatic breast drainage to axillary and internal mammary nodes.
-{:.figure-caption}
-
-![Figure 5-3: Sites for spread of breast cancer](images/fig-5-3.svg)
-
-Figure 5-3: Sites for spread of breast cancer
-{:.figure-caption}
+> ![Figure 5-3: Sites for spread of breast cancer](images/fig-5-3.svg)
+> 
+> Figure 5-3: Sites for spread of breast cancer
+{:.figure}
 
 ### 5-9 What makes a cancer more likely to spread?
 
 The behaviour of a breast cancer is dependent on how ‘sticky’ the cells are which determines how strongly they remain attached to each other. Cells that are less ‘sticky’ tend to break off and spread.
 
-![Figure 5-4: Method of cancer spread](images/fig-5-4.svg)
-
-Figure 5-4: Method of cancer spread
-{:.figure-caption}
+> ![Figure 5-4: Method of cancer spread](images/fig-5-4.svg)
+> 
+> Figure 5-4: Method of cancer spread
+{:.figure}
 
 ### 5-10 Do all cancers behave in the same way?
 

--- a/breast-care/6.md
+++ b/breast-care/6.md
@@ -177,10 +177,10 @@ Wide local excision is sometimes referred to as:
 
 Although terms may differ slightly, they basically mean the same thing.
 
-![Figure 6-1: Wide local excision of a breast lump](images/fig-6-1.svg)
-
-Figure 6-1: Wide local excision of a breast lump
-{:.figure-caption}
+> ![Figure 6-1: Wide local excision of a breast lump](images/fig-6-1.svg)
+> 
+> Figure 6-1: Wide local excision of a breast lump
+{:.figure}
 
 ### 6-17 What is a wide local excision?
 
@@ -258,10 +258,10 @@ They can be immediate, delayed or started with an expander at the time of surger
 *	*Delayed reconstruction*: initially a skin-reducing mastectomy is performed. All cancer management is finished (this may include radiotherapy) and then a reconstruction is started from scratch sometime later.
 *	*Expander placement*: at the time of the cancer surgery, an expander may be placed under the muscle or skin. The skin is then gradually stretched up over the next few months and the final surgery is done when all cancer treatment has finished. This allows some skin to be removed at the time of surgery and eventually, the reconstruction is done using the chest wall skin.
 
-![Figure 6-2: Use of an expander after mastectomy](images/fig-6-2.svg)
-
-Figure 6-2: Use of an expander after mastectomy
-{:.figure-caption}
+> ![Figure 6-2: Use of an expander after mastectomy](images/fig-6-2.svg)
+> 
+> Figure 6-2: Use of an expander after mastectomy
+{:.figure}
 
 ### 6-26 What types of reconstruction are there?
 
@@ -272,20 +272,20 @@ There are two types of reconstruction:
 	*	Muscle can be used. The Latissimus Dorsi (LD) flap uses the muscle from the women’s back to create a new breast.
 2.	Prosthetic reconstructions using a silicone prosthesis.
 
-![Figure 6-3: Examples of autologous reconstruction: TRAM flap and DIEP flap.](images/fig-6-3.svg)
+> ![Figure 6-3: Examples of autologous reconstruction: TRAM flap and DIEP flap.](images/fig-6-3.svg)
+> 
+> Figure 6-3: Examples of autologous reconstruction: TRAM flap and DIEP flap.
+{:.figure}
 
-Figure 6-3: Examples of autologous reconstruction: TRAM flap and DIEP flap.
-{:.figure-caption}
+> ![Figure 6-4: Latissimus Dorsi (LD) flap](images/fig-6-4.svg)
+> 
+> Figure 6-4: Latissimus Dorsi (LD) flap
+{:.figure}
 
-![Figure 6-4: Latissimus Dorsi (LD) flap](images/fig-6-4.svg)
-
-Figure 6-4: Latissimus Dorsi (LD) flap
-{:.figure-caption}
-
-![Figure 6-5: Examples of a prosthetic reconstruction. On the right, silicone-containing prostheses](images/fig-.svg)
-
-Figure 6-5: Examples of a prosthetic reconstruction. On the right, silicone-containing prostheses
-{:.figure-caption}
+> ![Figure 6-5: Examples of a prosthetic reconstruction. On the right, silicone-containing prostheses](images/fig-.svg)
+> 
+> Figure 6-5: Examples of a prosthetic reconstruction. On the right, silicone-containing prostheses
+{:.figure}
 
 ## Axillary surgery
 

--- a/breast-care/8.md
+++ b/breast-care/8.md
@@ -399,10 +399,10 @@ Wherever possible, ensure that someone can reassure and stay with the patient wh
 
 Some patients may benefit from a physiotherapist who can teach them breathing exercises which can stop them hyperventilating. Patients with a severe lung problem may need catheter oxygen. Nebulisation with saline can help for breathlessness while bronchodilators can be used if the patient is wheezing or if their ‘chest feels tight’.
 
-![Figure 8-1: Semi-Fowler’s position](images/fig-8-1.svg)
-
-Figure 8-1: Semi-Fowler’s position
-{:.figure-caption}
+> ![Figure 8-1: Semi-Fowler’s position](images/fig-8-1.svg)
+> 
+> Figure 8-1: Semi-Fowler’s position
+{:.figure}
 
 ### 8-45 What medication can be given to improve breathlessness?
 

--- a/child-healthcare/1.md
+++ b/child-healthcare/1.md
@@ -77,10 +77,10 @@ It is always very important to ask for and review the child’s Road-to-Health C
 
 > Always look carefully at the Road-to-Health Card before examining a child.
 
-![Figure 1-1: A WHO Road-to-Health Card Growth Monitoring Chart](images/1-1.svg)
-
-Figure 1-1: A WHO Road-to-Health Card Growth Monitoring Chart
-{:.figure-caption}
+> ![Figure 1-1: A WHO Road-to-Health Card Growth Monitoring Chart](images/1-1.svg)
+> 
+> Figure 1-1: A WHO Road-to-Health Card Growth Monitoring Chart
+{:.figure}
 
 ## Basic information
 

--- a/child-healthcare/15.md
+++ b/child-healthcare/15.md
@@ -375,10 +375,10 @@ The aim of ChildPIP is to determine the mortality rates, causes of death and mod
 
 *Figure 15-1 shows the data collection sheet for childhood deaths from ChildPIP.*
 
-![Figure 15-1: The data collection sheet for childhood deaths from the ChildPIP](images/15-1.svg)
-
-Figure 15-1: The data collection sheet for childhood deaths from the ChildPIP
-{:.figure-caption}
+> ![Figure 15-1: The data collection sheet for childhood deaths from the ChildPIP](images/15-1.svg)
+> 
+> Figure 15-1: The data collection sheet for childhood deaths from the ChildPIP
+{:.figure}
 
 ## Ways of avoiding the common causes of under 5 deaths
 

--- a/child-healthcare/16.md
+++ b/child-healthcare/16.md
@@ -6,82 +6,82 @@ layout: chapter
 
 # Skin conditions: photographs
 
-![Acne](images/p-1.jpg)
+> ![Acne](images/p-1.jpg)
+> 
+> Acne
+{:.figure}
 
-Acne
-{:.figure-caption}
+> ![Acute eczema](images/p-2.jpg)
+> 
+> Acute eczema
+{:.figure}
 
-![Acute eczema](images/p-2.jpg)
+> ![Impetigo](images/p-3.jpg)
+> 
+> Impetigo
+{:.figure}
 
-Acute eczema
-{:.figure-caption}
+> ![Herpes simplex](images/p-4.jpg)
+> 
+> Herpes simplex
+{:.figure}
 
-![Impetigo](images/p-3.jpg)
+> ![Chronic eczema](images/p-5.jpg)
+> 
+> Chronic eczema
+{:.figure}
 
-Impetigo
-{:.figure-caption}
+> ![Chicken pox](images/p-6.jpg)
+> 
+> Chicken pox
+{:.figure}
 
-![Herpes simplex](images/p-4.jpg)
+> ![HIV rash](images/p-7.jpg)
+> 
+> HIV rash
+{:.figure}
 
-Herpes simplex
-{:.figure-caption}
+> ![Seborrhoeic dermatitis](images/p-8.jpg)
+> 
+> Seborrhoeic dermatitis
+{:.figure}
 
-![Chronic eczema](images/p-5.jpg)
+> ![Measles](images/p-9.jpg)
+> 
+> Measles
+{:.figure}
 
-Chronic eczema
-{:.figure-caption}
+> ![Ringworm](images/p-10.jpg)
+> 
+> Ringworm
+{:.figure}
 
-![Chicken pox](images/p-6.jpg)
+> ![Molluscum contagiosum](images/p-11.jpg)
+> 
+> Molluscum contagiosum
+{:.figure}
 
-Chicken pox
-{:.figure-caption}
+> ![Pellagra rash](images/p-12.jpg)
+> 
+> Pellagra rash
+{:.figure}
 
-![HIV rash](images/p-7.jpg)
+> ![Meningococcal septicaemia](images/p-13.jpg)
+> 
+> Meningococcal septicaemia
+{:.figure}
 
-HIV rash
-{:.figure-caption}
+> ![Lice](images/p-14.jpg)
+> 
+> Lice
+{:.figure}
 
-![Seborrhoeic dermatitis](images/p-8.jpg)
+> ![Scabies](images/p-15.jpg)
+> 
+> Scabies
+{:.figure}
 
-Seborrhoeic dermatitis
-{:.figure-caption}
-
-![Measles](images/p-9.jpg)
-
-Measles
-{:.figure-caption}
-
-![Ringworm](images/p-10.jpg)
-
-Ringworm
-{:.figure-caption}
-
-![Molluscum contagiosum](images/p-11.jpg)
-
-Molluscum contagiosum
-{:.figure-caption}
-
-![Pellagra rash](images/p-12.jpg)
-
-Pellagra rash
-{:.figure-caption}
-
-![Meningococcal septicaemia](images/p-13.jpg)
-
-Meningococcal septicaemia
-{:.figure-caption}
-
-![Lice](images/p-14.jpg)
-
-Lice
-{:.figure-caption}
-
-![Scabies](images/p-15.jpg)
-
-Scabies
-{:.figure-caption}
-
-![Papular urticaria](images/p-16.jpg)
-
-Papular urticaria
-{:.figure-caption}
+> ![Papular urticaria](images/p-16.jpg)
+> 
+> Papular urticaria
+{:.figure}

--- a/child-healthcare/2.md
+++ b/child-healthcare/2.md
@@ -551,10 +551,10 @@ Avoid direct sunlight and do not use alcohol or ether to clean vials of live vac
 
 Polio vaccine has a heat sensitive spot on each vial. Normally the dot is white but it darkens if the vaccine is not kept cool correctly. If the dot is the colour of the surrounding circle, or darker, it is damaged and must not be used.
 
-![Figure 2-1 Polio vaccine vial monitor](images/2-1.svg)
-
-Figure 2-1 Polio vaccine vial monitor
-{:.figure-caption}
+> ![Figure 2-1 Polio vaccine vial monitor](images/2-1.svg)
+> 
+> Figure 2-1 Polio vaccine vial monitor
+{:.figure}
 
 ### 2-64 What is ‘the cold chain’?
 
@@ -837,7 +837,7 @@ Table 2-2: Summary of immunisations routinely used
   </tr>
 </table>
 
-![Figure 2-2: Road-to-Health Card immunisation record](images/2-2.svg)
-
-Figure 2-2: Road-to-Health Card immunisation record
-{:.figure-caption}
+> ![Figure 2-2: Road-to-Health Card immunisation record](images/2-2.svg)
+> 
+> Figure 2-2: Road-to-Health Card immunisation record
+{:.figure}

--- a/child-healthcare/3.md
+++ b/child-healthcare/3.md
@@ -174,10 +174,10 @@ The same method is used to plot the infant’s height (or length) and head circu
 
 At the first visit it is helpful to fill in the calendar months along the bottom of the centile chart, starting with the month in which the child was born. This is done so that further growth is easily plotted.
 
-![Figure 3-1: Plotting a child’s weight on a centile chart](images/3-1.svg)
-
-Figure 3-1: Plotting a child’s weight on a centile chart
-{:.figure-caption}
+> ![Figure 3-1: Plotting a child’s weight on a centile chart](images/3-1.svg)
+> 
+> Figure 3-1: Plotting a child’s weight on a centile chart
+{:.figure}
 
 ### 3-19 Can length and height both be plotted on the same chart?
 
@@ -195,10 +195,10 @@ A growth curve (or growth line) illustrates the way a child is growing over a pe
 
 > A growth curve is a line linking size measurements recorded over time.
 
-![Figure 3-2: A normal growth curve plotted on a centile chart](images/3-2.svg)
-
-Figure 3-2: A normal growth curve plotted on a centile chart
-{:.figure-caption}
+> ![Figure 3-2: A normal growth curve plotted on a centile chart](images/3-2.svg)
+> 
+> Figure 3-2: A normal growth curve plotted on a centile chart
+{:.figure}
 
 ### 3-22 What is the value of a growth curve?
 
@@ -288,10 +288,10 @@ Infants with growth faltering (failure to thrive or slow growth) have not been g
 
 > Slow growth or growth faltering are important signs that the child may be ill or not getting enough food.
 
-![Figure 3-3: A growth-faltering curve plotted on a centile chart](images/3-3.svg)
-
-Figure 3-3: A growth-faltering curve plotted on a centile chart
-{:.figure-caption}
+> ![Figure 3-3: A growth-faltering curve plotted on a centile chart](images/3-3.svg)
+> 
+> Figure 3-3: A growth-faltering curve plotted on a centile chart
+{:.figure}
 
 ### 3-35 How can you recognise stunting?
 
@@ -562,70 +562,67 @@ It is difficult to get an overweight child to lose weight. The whole family has 
 
 ## International centile charts
 
-![Figure 3-4: The Growth Monitoring Chart on the the Road-to-Health Card](images/3-4.svg)
+> ![Figure 3-4: The Growth Monitoring Chart on the the Road-to-Health Card](images/3-4.svg)
+> 
+> Figure 3-4: The Growth Monitoring Chart on the the Road-to-Health Card
+{:.figure}
 
-Figure 3-4: The Growth Monitoring Chart on the the Road-to-Health Card
-{:.figure-caption}
+> ![Figure 3-5: Weight-for-age percentiles: Boys, birth to 36 months](images/3-5.svg)
+> 
+> Figure 3-5: Weight-for-age percentiles: Boys, birth to 36 months
+{:.figure}
 
-![Figure 3-5: Weight-for-age percentiles: Boys, birth to 36 months](images/3-5.svg)
+> ![Figure 3-6: Weight-for-age percentiles: Girls, birth to 36 months](images/3-6.svg)
+> 
+> Figure 3-6: Weight-for-age percentiles: Girls, birth to 36 months
+{:.figure}
 
-Figure 3-5: Weight-for-age percentiles: Boys, birth to 36 months
-{:.figure-caption}
+> ![Figure 3-7: Length-for-age percentiles: Boys, birth to 36 months](images/3-7.svg)
+> 
+> Figure 3-7: Length-for-age percentiles: Boys, birth to 36 months
+{:.figure}
 
-![Figure 3-6: Weight-for-age percentiles: Girls, birth to 36 months](images/3-6.svg)
+> ![Figure 3-8: Length-for-age percentiles: Girls, birth to 36 months](images/3-8.svg)
+> 
+> Figure 3-8: Length-for-age percentiles: Girls, birth to 36 months
+{:.figure}
 
-Figure 3-6: Weight-for-age percentiles: Girls, birth to 36 months
-{:.figure-caption}
+> ![Figure 3-9: Head circumference-for-age percentiles: Boys, birth to 36 months](images/3-9.svg)
+> 
+> Figure 3-9: Head circumference-for-age percentiles: Boys, birth to 36 months
+{:.figure}
 
-![Figure 3-7: Length-for-age percentiles: Boys, birth to 36 months](images/3-7.svg)
+> ![Figure 3-10: Head circumference-for-age percentiles: Girls, birth to 36 months](images/3-10.svg)
+> 
+> Figure 3-10: Head circumference-for-age percentiles: Girls, birth to 36 months
+{:.figure}
 
-Figure 3-7: Length-for-age percentiles: Boys, birth to 36 months
-{:.figure-caption}
+> ![Figure 3-11: Weight-for-age percentiles: Boys, 2 to 20 years](images/3-11.svg)
+> 
+> Figure 3-11: Weight-for-age percentiles: Boys, 2 to 20 years
+{:.figure}
 
-![Figure 3-8: Length-for-age percentiles: Girls, birth to 36 months](images/3-8.svg)
+> ![Figure 3-12: Weight-for-age percentiles: Girls, 2 to 20 years](images/3-12.svg)
+> 
+> Figure 3-12: Weight-for-age percentiles: Girls, 2 to 20 years
+{:.figure}
 
-Figure 3-8: Length-for-age percentiles: Girls, birth to 36 months
-{:.figure-caption}
+> ![Figure 3-13: Stature-for-age percentiles: Boys, 2 to 20 years](images/3-13.svg)
+> 
+> Figure 3-13: Stature-for-age percentiles: Boys, 2 to 20 years
+{:.figure}
 
-![Figure 3-9: Head circumference-for-age percentiles: Boys, birth to 36 months](images/3-9.svg)
+> ![Figure 3-14: Stature-for-age percentiles: Girls, 2 to 20 years](images/3-14.svg)
+> 
+> Figure 3-14: Stature-for-age percentiles: Girls, 2 to 20 years
+{:.figure}
 
-Figure 3-9: Head circumference-for-age percentiles: Boys, birth to 36 months
-{:.figure-caption}
+> ![Figure 3-15: Body mass index-for-age percentiles: Boys, 2 to 20 years](images/3-15.svg)
+> 
+> Figure 3-15: Body mass index-for-age percentiles: Boys, 2 to 20 years
+{:.figure}
 
-![Figure 3-10: Head circumference-for-age percentiles: Girls, birth to 36 months](images/3-10.svg)
-
-Figure 3-10: Head circumference-for-age percentiles: Girls, birth to 36 months
-{:.figure-caption}
-
-![Figure 3-11: Weight-for-age percentiles: Boys, 2 to 20 years](images/3-11.svg)
-
-Figure 3-11: Weight-for-age percentiles: Boys, 2 to 20 years
-{:.figure-caption}
-
-![Figure 3-12: Weight-for-age percentiles: Girls, 2 to 20 years](images/3-12.svg)
-
-Figure 3-12: Weight-for-age percentiles: Girls, 2 to 20 years
-{:.figure-caption}
-
-![Figure 3-13: Stature-for-age percentiles: Boys, 2 to 20 years](images/3-13.svg)
-
-Figure 3-13: Stature-for-age percentiles: Boys, 2 to 20 years
-{:.figure-caption}
-
-
-![Figure 3-14: Stature-for-age percentiles: Girls, 2 to 20 years](images/3-14.svg)
-
-Figure 3-14: Stature-for-age percentiles: Girls, 2 to 20 years
-{:.figure-caption}
-
-
-![Figure 3-15: Body mass index-for-age percentiles: Boys, 2 to 20 years](images/3-15.svg)
-
-Figure 3-15: Body mass index-for-age percentiles: Boys, 2 to 20 years
-{:.figure-caption}
-
-
-![Figure 3-16: Body mass index-for-age percentiles: Girls, 2 to 20 years](images/3-16.svg)
-
-Figure 3-16: Body mass index-for-age percentiles: Girls, 2 to 20 years
-{:.figure-caption}
+> ![Figure 3-16: Body mass index-for-age percentiles: Girls, 2 to 20 years](images/3-16.svg)
+> 
+> Figure 3-16: Body mass index-for-age percentiles: Girls, 2 to 20 years
+{:.figure}

--- a/childhood-hiv/2.md
+++ b/childhood-hiv/2.md
@@ -32,10 +32,10 @@ Therefore the amount of virus in the blood is high early and late in the course 
 
 > HIV infects CD4 cells and slowly damages the immune system.
 
-![Figure 2-1: The changes in viral load, CD4 count and clinical features of HIV infection in adults](images/2-1.svg)
-
-Figure 2-1: The changes in viral load, CD4 count and clinical features of HIV infection in adults
-{:.figure-caption}
+> ![Figure 2-1: The changes in viral load, CD4 count and clinical features of HIV infection in adults](images/2-1.svg)
+> 
+> Figure 2-1: The changes in viral load, CD4 count and clinical features of HIV infection in adults
+{:.figure}
 
 ### 2-2 Do children become ill as soon as they are infected with HIV?
 

--- a/childhood-hiv/4.md
+++ b/childhood-hiv/4.md
@@ -70,10 +70,10 @@ Note
 
 See Figure 4-1, which shows the multiplication of HIV.
 
-![Figure 4-1: Sites at which antiretroviral drugs act (reverse transcription and formation of new virus particle)](images/.svg)
-
-Figure 4-1: Sites at which antiretroviral drugs act (reverse transcription and formation of new virus particle)
-{:.figure-caption}
+> ![Figure 4-1: Sites at which antiretroviral drugs act (reverse transcription and formation of new virus particle)](images/.svg)
+> 
+> Figure 4-1: Sites at which antiretroviral drugs act (reverse transcription and formation of new virus particle)
+{:.figure}
 
 ### 4-5 What are common examples of ‘nucs’?
 

--- a/childhood-tb/0-4-acknowledgements.md
+++ b/childhood-tb/0-4-acknowledgements.md
@@ -20,5 +20,5 @@ The funding for this project was obtained from a United States Agency for Intern
 
 *Prof David Woods and Prof Robert Gie*
 
-![Desmond Tutu TB Centre](images/desmond-tutu-tb-centre-logo.svg){:.quarter-page}&nbsp;
-![TBCTA – USAID](images/tbcta-usaid-logo.svg){:.quarter-page}
+![Desmond Tutu TB Centre](images/desmond-tutu-tb-centre-logo.svg){:.titlepage-logo}&nbsp;
+![TBCTA – USAID](images/tbcta-usaid-logo.svg){:.titlepage-logo}

--- a/css/epub.css
+++ b/css/epub.css
@@ -243,6 +243,7 @@ blockquote.figure p {
 }
 blockquote.figure p img {
 	width: 100%;
+	max-height: 20em;
 	padding: 0.5em 0 1em 0;
 	margin: 0 0 0.5em 0;
 	border-bottom: 1px dashed #ccc;
@@ -253,6 +254,7 @@ blockquote.figure.small p img {
 }
 blockquote.figure.large p img {
 	width: 100%;
+	max-height: inherit;
 }
 
 /*

--- a/css/epub.css
+++ b/css/epub.css
@@ -221,30 +221,38 @@ pre, code {
 	white-space: pre-wrap;
 }
 
-/* 
- * Figures and images
- */
+/* Figures. Note: we use the blockquote element to wrap figures and their captions in valid XHTML. 
+ * Use the .figure class for the blockquote wrapping an image and a caption. Add .fixed, .small and/or .large for layout and size options. */
 
-img {
-	max-width: 100%;
+blockquote.figure {
+	clear: both;
+	page-break-inside: avoid;
+	background-color: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	color: #666;
+	border: 1px solid #666;
+	border-radius: 0.25em;
 	margin: 1em 0;
+	padding: 0.5em;
 }
-.figure-caption {
-	font-style: italic;
+blockquote.figure p {
+	clear: both;
+	page-break-inside: avoid;
 	page-break-before: avoid;
-	margin: 0 0 1em 0;
 }
-.full-width img, img.full-width {
+blockquote.figure p img {
 	width: 100%;
+	padding: 0.5em 0 1em 0;
+	margin: 0 0 0.5em 0;
+	border-bottom: 1px dashed #ccc;
 }
-.full-page img, img.full-page {
+blockquote.figure.small p img {
 	max-width: 100%;
+	max-height: 10em;
 }
-.half-page img, img.half-page {
-	max-width: 50%;
-}
-.quarter-page img, img.quarter-page {
-	max-width: 25%;
+blockquote.figure.large p img {
+	width: 100%;
 }
 
 /*

--- a/css/print.css
+++ b/css/print.css
@@ -276,6 +276,18 @@ li:last-of-type {
 li li:first-of-type {
 	page-break-before: auto;
 }
+pre, code {
+	font-family: "Linux Libertine Mono", monospace;
+	white-space: pre-wrap;
+	line-height: 1em;
+}
+a {
+	text-decoration: none;
+	color: inherit;
+}
+
+/* Key concept boxes. Note: we use the blockquote element as our default element for key-concept boxes. */
+
 blockquote {
 	clear: both;
 	font-family: "Source Sans Pro", sans-serif;
@@ -297,6 +309,9 @@ blockquote.box {
 	font-weight: inherit;
 	font-size: inherit;
 	border: 1px solid #ccc;
+
+/* Definition lists. Note: we use the dl element as our default element for notes. */
+
 }
 dl {
 	font-family: "Source Sans Pro", sans-serif;
@@ -313,15 +328,6 @@ dt {
 }
 dd .table-caption {
 	margin-top: 1em;
-}
-pre, code {
-	font-family: "Linux Libertine Mono", monospace;
-	white-space: pre-wrap;
-	line-height: 1em;
-}
-a {
-	text-decoration: none;
-	color: inherit;
 }
 
 /*
@@ -365,30 +371,44 @@ td p {
 	padding: 0;
 }
 
-/*
- * Figures and images
- */
+/* Figures. Note: we use the blockquote element to wrap figures and their captions in valid XHTML. 
+ * Use the .figure class for the blockquote wrapping an image and a caption. Add .fixed, .small and/or .large for layout and size options. */
 
-img {
-	max-width: 100%;
-	margin: 0.5em 0;
+blockquote.figure {
+	clear: both;
+	float: prince-snap;
+	page-break-inside: avoid;
+	background-color: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	color: inherit;
+	border: 0.5pt solid #666;
+	border-radius: 0.25em;
+	margin: 1em 0;
+	padding: 0.5em;
 }
-.figure-caption {
-	font-style: italic;
+blockquote.fixed {
+	float: none; /* For figures that must keep their position in the text flow, not float to the top of the page. */
+}
+blockquote.figure p {
+	clear: both;
+	page-break-inside: avoid;
 	page-break-before: avoid;
-	margin: 0 0 1em 0;
 }
-.full-width img, img.full-width {
+blockquote.figure p img {
 	width: 100%;
+	max-height: 75mm;
+	padding: 0.5em 0 1em 0;
+	margin: 0 0 0.5em 0;
+	border-bottom: 0.5pt dashed #ccc;
 }
-.full-page img, img.full-page {
+blockquote.figure.small p img {
+	max-width: 100%;
+	max-height: 45mm;
+}
+blockquote.figure.large p img {
+	width: 100%;
 	max-height: 150mm;
-}
-.half-page img, img.half-page {
-	max-height: 55mm;
-}
-.quarter-page img, img.quarter-page {
-	max-height: 25mm;
 }
 
 /*

--- a/css/print_no-crops-no-bleed.css
+++ b/css/print_no-crops-no-bleed.css
@@ -276,6 +276,18 @@ li:last-of-type {
 li li:first-of-type {
 	page-break-before: auto;
 }
+pre, code {
+	font-family: "Linux Libertine Mono", monospace;
+	white-space: pre-wrap;
+	line-height: 1em;
+}
+a {
+	text-decoration: none;
+	color: inherit;
+}
+
+/* Key concept boxes. Note: we use the blockquote element as our default element for key-concept boxes. */
+
 blockquote {
 	clear: both;
 	font-family: "Source Sans Pro", sans-serif;
@@ -297,6 +309,9 @@ blockquote.box {
 	font-weight: inherit;
 	font-size: inherit;
 	border: 1px solid #ccc;
+
+/* Definition lists. Note: we use the dl element as our default element for notes. */
+
 }
 dl {
 	font-family: "Source Sans Pro", sans-serif;
@@ -313,15 +328,6 @@ dt {
 }
 dd .table-caption {
 	margin-top: 1em;
-}
-pre, code {
-	font-family: "Linux Libertine Mono", monospace;
-	white-space: pre-wrap;
-	line-height: 1em;
-}
-a {
-	text-decoration: none;
-	color: inherit;
 }
 
 /*
@@ -365,30 +371,44 @@ td p {
 	padding: 0;
 }
 
-/*
- * Figures and images
- */
+/* Figures. Note: we use the blockquote element to wrap figures and their captions in valid XHTML. 
+ * Use the .figure class for the blockquote wrapping an image and a caption. Add .fixed, .small and/or .large for layout and size options. */
 
-img {
-	max-width: 100%;
-	margin: 0.5em 0;
+blockquote.figure {
+	clear: both;
+	float: prince-snap;
+	page-break-inside: avoid;
+	background-color: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	color: inherit;
+	border: 0.5pt solid #666;
+	border-radius: 0.25em;
+	margin: 1em 0;
+	padding: 0.5em;
 }
-.figure-caption {
-	font-style: italic;
+blockquote.fixed {
+	float: none; /* For figures that must keep their position in the text flow, not float to the top of the page. */
+}
+blockquote.figure p {
+	clear: both;
+	page-break-inside: avoid;
 	page-break-before: avoid;
-	margin: 0 0 1em 0;
 }
-.full-width img, img.full-width {
+blockquote.figure p img {
 	width: 100%;
+	max-height: 75mm;
+	padding: 0.5em 0 1em 0;
+	margin: 0 0 0.5em 0;
+	border-bottom: 0.5pt dashed #ccc;
 }
-.full-page img, img.full-page {
+blockquote.figure.small p img {
+	max-width: 100%;
+	max-height: 45mm;
+}
+blockquote.figure.large p img {
+	width: 100%;
 	max-height: 150mm;
-}
-.half-page img, img.half-page {
-	max-height: 55mm;
-}
-.quarter-page img, img.quarter-page {
-	max-height: 25mm;
 }
 
 /*

--- a/css/print_no-crops.css
+++ b/css/print_no-crops.css
@@ -276,6 +276,18 @@ li:last-of-type {
 li li:first-of-type {
 	page-break-before: auto;
 }
+pre, code {
+	font-family: "Linux Libertine Mono", monospace;
+	white-space: pre-wrap;
+	line-height: 1em;
+}
+a {
+	text-decoration: none;
+	color: inherit;
+}
+
+/* Key concept boxes. Note: we use the blockquote element as our default element for key-concept boxes. */
+
 blockquote {
 	clear: both;
 	font-family: "Source Sans Pro", sans-serif;
@@ -297,6 +309,9 @@ blockquote.box {
 	font-weight: inherit;
 	font-size: inherit;
 	border: 1px solid #ccc;
+
+/* Definition lists. Note: we use the dl element as our default element for notes. */
+
 }
 dl {
 	font-family: "Source Sans Pro", sans-serif;
@@ -313,15 +328,6 @@ dt {
 }
 dd .table-caption {
 	margin-top: 1em;
-}
-pre, code {
-	font-family: "Linux Libertine Mono", monospace;
-	white-space: pre-wrap;
-	line-height: 1em;
-}
-a {
-	text-decoration: none;
-	color: inherit;
 }
 
 /*
@@ -365,30 +371,44 @@ td p {
 	padding: 0;
 }
 
-/*
- * Figures and images
- */
+/* Figures. Note: we use the blockquote element to wrap figures and their captions in valid XHTML. 
+ * Use the .figure class for the blockquote wrapping an image and a caption. Add .fixed, .small and/or .large for layout and size options. */
 
-img {
-	max-width: 100%;
-	margin: 0.5em 0;
+blockquote.figure {
+	clear: both;
+	float: prince-snap;
+	page-break-inside: avoid;
+	background-color: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	color: inherit;
+	border: 0.5pt solid #666;
+	border-radius: 0.25em;
+	margin: 1em 0;
+	padding: 0.5em;
 }
-.figure-caption {
-	font-style: italic;
+blockquote.fixed {
+	float: none; /* For figures that must keep their position in the text flow, not float to the top of the page. */
+}
+blockquote.figure p {
+	clear: both;
+	page-break-inside: avoid;
 	page-break-before: avoid;
-	margin: 0 0 1em 0;
 }
-.full-width img, img.full-width {
+blockquote.figure p img {
 	width: 100%;
+	max-height: 75mm;
+	padding: 0.5em 0 1em 0;
+	margin: 0 0 0.5em 0;
+	border-bottom: 0.5pt dashed #ccc;
 }
-.full-page img, img.full-page {
+blockquote.figure.small p img {
+	max-width: 100%;
+	max-height: 45mm;
+}
+blockquote.figure.large p img {
+	width: 100%;
 	max-height: 150mm;
-}
-.half-page img, img.half-page {
-	max-height: 55mm;
-}
-.quarter-page img, img.quarter-page {
-	max-height: 25mm;
 }
 
 /*

--- a/css/screen.css
+++ b/css/screen.css
@@ -288,6 +288,7 @@ blockquote.figure p {
 }
 blockquote.figure p img {
 	width: 100%;
+	max-height: 20em;
 	padding: 0.5em 0 1em 0;
 	margin: 0 0 0.5em 0;
 	border-bottom: 1px dashed #ccc;
@@ -298,6 +299,7 @@ blockquote.figure.small p img {
 }
 blockquote.figure.large p img {
 	width: 100%;
+	max-height: inherit;
 }
 
 /*

--- a/css/screen.css
+++ b/css/screen.css
@@ -266,30 +266,38 @@ pre, code {
 	white-space: pre-wrap;
 }
 
-/* 
- * Figures and images
- */
+/* Figures. Note: we use the blockquote element to wrap figures and their captions in valid XHTML. 
+ * Use the .figure class for the blockquote wrapping an image and a caption. Add .fixed, .small and/or .large for layout and size options. */
 
-img {
-	max-width: 100%;
+blockquote.figure {
+	clear: both;
+	page-break-inside: avoid;
+	background-color: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	color: #666;
+	border: 1px solid #666;
+	border-radius: 0.25em;
 	margin: 1em 0;
+	padding: 0.5em;
 }
-.figure-caption {
-	font-style: italic;
+blockquote.figure p {
+	clear: both;
+	page-break-inside: avoid;
 	page-break-before: avoid;
-	margin: 0 0 1em 0;
 }
-.full-width img, img.full-width {
+blockquote.figure p img {
 	width: 100%;
+	padding: 0.5em 0 1em 0;
+	margin: 0 0 0.5em 0;
+	border-bottom: 1px dashed #ccc;
 }
-.full-page img, img.full-page {
+blockquote.figure.small p img {
 	max-width: 100%;
+	max-height: 10em;
 }
-.half-page img, img.half-page {
-	max-width: 50%;
-}
-.quarter-page img, img.quarter-page {
-	max-width: 25%;
+blockquote.figure.large p img {
+	width: 100%;
 }
 
 /*

--- a/ebola-prevention-and-control/1.md
+++ b/ebola-prevention-and-control/1.md
@@ -42,10 +42,10 @@ Viruses (a type of microorganism) are very small and not visible to the naked ey
 
 Viruses are much smaller than other microorganisms such as bacteria (one hundredth of the size of a bacterium). They can only be seen using a specialised electron microscope, which enlarges the image up to 10 million times. Viruses are grouped by their genetic make-up and their shape.
 
-![Figure 1-1: Diagram of a generic virus](images/1-1.svg)
-
-Figure 1-1: Diagram of a generic virus
-{:.figure-caption}
+> ![Figure 1-1: Diagram of a generic virus](images/1-1.svg)
+> 
+> Figure 1-1: Diagram of a generic virus
+{:.figure}
 
 Note
 :	Viruses are classified by their genetic make-up (single- or double-stranded, RNA or DNA) and their shape (icosahedral, helical or complex). Virus particles (known as virions) have at least two parts: the nucleic acid (genetic material/genome) and the protein capsid (outer shell). Some viruses have a third component, called the virus envelope (or outer membrane). The virus envelope is composed of viral lipids and proteins and is easily damaged by heat, disinfectants and detergents. Other viruses are 'naked' or non-enveloped, making them more difficult to destroy or remove by disinfection. Ebola is a single-stranded RNA virus with an envelope.
@@ -215,11 +215,10 @@ The following instructions should be adhered to when preparing specimens for tra
 *	The shipping box should be labelled as bio-hazardous, with a warning that it must not be opened except in the specified laboratory by the specified person. If the transport time to the laboratory is expected to be more than one hour, the specimens must be placed in a cold box with cold packs.
 *	When preparing the containers for shipping the following disinfection steps must be applied: the outside of the primary container (test tube) must be profusely sprayed with disinfectant, placed into a secondary container which is then profusely sprayed with disinfectant, and then placed in the main transport/shipping box.
 
-![Figure 1-2: Improvised container for VHF laboratory samples (Source: Reproduced by kind permission of the South African Department of Health, National guidelines for recognition and management of viral haemorrhagic fevers, 2014.)](images/1-2.svg)
-{:.half-page}
-
-Figure 1-2: Improvised container for VHF laboratory samples (Source: Reproduced by kind permission of the South African Department of Health, National guidelines for recognition and management of viral haemorrhagic fevers, 2014.)
-{:.figure-caption}
+> ![Figure 1-2: Improvised container for VHF laboratory samples (Source: Reproduced by kind permission of the South African Department of Health, National guidelines for recognition and management of viral haemorrhagic fevers, 2014.)](images/1-2.svg)
+> 
+> Figure 1-2: Improvised container for VHF laboratory samples (Source: Reproduced by kind permission of the South African Department of Health, National guidelines for recognition and management of viral haemorrhagic fevers, 2014.)
+{:.figure}
 
 ### 1-18 How can laboratory specimens be processed safely?
 

--- a/ebola-prevention-and-control/3.md
+++ b/ebola-prevention-and-control/3.md
@@ -50,11 +50,10 @@ Standard infection control precautions are actions that reduce the chance of inf
 
 All healthcare workers should be trained in the use of standard precautions. The diagram below shows the elements that make up standard precautions with hand hygiene, protective clothing and patient placement (isolation) being some of the most important precautions in management of Ebola cases.
 
-![Figure 3-1: Standard precautions](images/3-1.svg)
-{:.full-width}
-
-Figure 3-1: Standard precautions
-{:.figure-caption}
+> ![Figure 3-1: Standard precautions](images/3-1.svg)
+>
+> Figure 3-1: Standard precautions
+{:.figure}
 
 > Standard precautions should be applied to all patients at all times, whether or not they are known to pose an infection risk.
 
@@ -202,37 +201,35 @@ The recommendations for personal protective equipment (PPE) for Ebola will vary 
 *	Foot cover: boots 
 *	Hand covers: two pairs of gloves.
 
-![Figure 3-2: Personal Protective Equipment (PPE) (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-2.svg)
-
-Figure 3-2: Personal Protective Equipment (PPE) (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
-{:.figure-caption}
+> ![Figure 3-2: Personal Protective Equipment (PPE) (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-2.svg)
+> 
+> Figure 3-2: Personal Protective Equipment (PPE) (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
+{:.figure}
 
 ### 3-14 Which types of eye protection are recommended?
 
 Any eye-cover that adequately protects the healthcare worker’s conjunctival mucous membranes from splashes is acceptable. Either goggles or face-shields (visors) can be used. Normal reading glasses are not acceptable, as fluid splashes can still reach the wearer’s eyes. Fogging (misting up) can be a problem when using some types of goggles.
 
-![Figure 3-3: Eye protection (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-3.svg)
+> ![Figure 3-3: Eye protection (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-3.svg)
+> 
+> Figure 3-3: Eye protection (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
+{:.figure}
 
-Figure 3-3: Eye protection (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
-{:.figure-caption}
-
-### 3-15 Which types of facecovers are recommended?
+### 3-15 Which types of face covers are recommended?
 
 Healthcare workers’ need to cover the mucous membranes of the mouth and nose to avoid body fluid splashes and droplet spread. A surgical mask or N95 respirator is acceptable. The WHO recommends a structured mask, e.g. a cup-shaped or duckbill (so-called 'face-off' mask). Ideally a face-shield should be worn over the mask/respirator.
 
-![Figure 3-4: Face covers (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-4.svg)
-{:.half-page}
-
-Figure 3-4: Face covers (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
-{:.figure-caption}
+> ![Figure 3-4: Face covers (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-4.svg)
+> 
+> Figure 3-4: Face covers (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
+{:.figure}
 
 ### 3-16 Which types of head cover are recommended?
 
-![Figure 3-5: Head covers](images/3-5.svg)
-{:.half-page}
-
-Figure 3-5: Head covers
-{:.figure-caption}
+> ![Figure 3-5: Head covers](images/3-5.svg)
+> 
+> Figure 3-5: Head covers
+{:.figure}
 
 The purpose of head covers is to protect the skin and hair from virus contamination, with possible subsequent unrecognised transmission to the mucosae of the eyes, nose or mouth. A headcover that also protects the neck and sides of the head (leaving no or as little as possible skin exposed) is preferred. Hair/hair extensions should all fit inside the head cover. A balaclava provides good head and neck cover.
 
@@ -244,10 +241,10 @@ Ideally the healthcare worker should change out of their private clothes into co
 
 Ideally the healthcare worker should wear correctly sized gumboots. Boots are preferred over closed shoes because they are easier to clean and disinfect. In addition they provide more protection when floors are wet and can protect from sharps injuries. If boots are not available, health workers must wear closed shoes (slip-on type without shoelaces that fully cover the foot and ankles). Shoe covers (nonslip and preferably impermeable) should be used over closed shoes to facilitate decontamination. WHO does not recommend the use of overshoes if wearing boots.
 
-![Figure 3-6: Footwear (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-6.svg)
-
-Figure 3-6: Footwear (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
-{:.figure-caption}
+> ![Figure 3-6: Footwear (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))](images/3-6.svg)
+> 
+> Figure 3-6: Footwear (Source: Reproduced with kind permission of the WHO Interim Infection Prevention and Control Guidance for Care of Patients with Suspected or Confirmed Filovirus Haemorrhagic Fever in Health-Care Settings, with Focus on Ebola (September 2014))
+{:.figure}
 
 ### 3-19 Which types of apron are recommended?
 
@@ -303,109 +300,96 @@ Follow your local recommended guideline for PPE removal or use the sequence reco
 
 #### Step 1
 
-![Figure 3-7: Pinch one glove at the wrist level to remove it without touching the skin of the forearm, and peel away from the hand, allowing the glove to turn inside out.](images/3-7.svg)
-{:.half-page}
-
-Figure 3-7: Pinch one glove at the wrist level to remove it without touching the skin of the forearm, and peel away from the hand, allowing the glove to turn inside out.
-{:.figure-caption}
+> ![Figure 3-7: Pinch one glove at the wrist level to remove it without touching the skin of the forearm, and peel away from the hand, allowing the glove to turn inside out.](images/3-7.svg)
+> 
+> Figure 3-7: Pinch one glove at the wrist level to remove it without touching the skin of the forearm, and peel away from the hand, allowing the glove to turn inside out.
+{:.figure .small}
 
 #### Step 2
 
-![](images/3-8.svg)
-{:.half-page}
-
-Figure 3-8: Hold the removed glove in the gloved hand and slide the fingers of the ungloved hand inside between the glove and the wrist. Remove the second glove by rolling it down the hand and fold into the first glove.
-{:.figure-caption}
+> ![Figure 3-8: Hold the removed glove in the gloved hand and slide the fingers of the ungloved hand inside between the glove and the wrist. Remove the second glove by rolling it down the hand and fold into the first glove.](images/3-8.svg)
+> 
+> Figure 3-8: Hold the removed glove in the gloved hand and slide the fingers of the ungloved hand inside between the glove and the wrist. Remove the second glove by rolling it down the hand and fold into the first glove.
+{:.figure .small .fixed}
 
 #### Step 3
 
-![Figure 3-9: Discard the removed gloves in an appropriate waste container.](images/3-9.svg)
-{:.half-page}
-
-Figure 3-9: Discard the removed gloves in an appropriate waste container.
-{:.figure-caption}
+> ![Figure 3-9: Discard the removed gloves in an appropriate waste container.](images/3-9.svg)
+> 
+> Figure 3-9: Discard the removed gloves in an appropriate waste container.
+{:.figure .small .fixed}
 
 #### Step 4
 
-![Figure 3-10: Perform hand hygiene with 70% alcohol handrub (if hands visibly clean) or with soap and water (if visibly contaminated).](images/3-10.svg)
-{:.half-page}
-
-Figure 3-10: Perform hand hygiene with 70% alcohol handrub (if hands visibly clean) or with soap and water (if visibly contaminated).
-{:.figure-caption}
+> ![Figure 3-10: Perform hand hygiene with 70% alcohol handrub (if hands visibly clean) or with soap and water (if visibly contaminated).](images/3-10.svg)
+> 
+> Figure 3-10: Perform hand hygiene with 70% alcohol handrub (if hands visibly clean) or with soap and water (if visibly contaminated).
+{:.figure .small .fixed}
 
 ### How to remove PPE
 
 #### Step 1
 
-![Figure 3-11: Peel off plastic apron and dispose of safely (if the apron is to be reused, place in a container with disinfectant).](images/3-11.svg)
-{:.half-page}
-
-Figure 3-11: Peel off plastic apron and dispose of safely (if the apron is to be reused, place in a container with disinfectant).
-{:.figure-caption}
+> ![Figure 3-11: Peel off plastic apron and dispose of safely (if the apron is to be reused, place in a container with disinfectant).](images/3-11.svg)
+> 
+> Figure 3-11: Peel off plastic apron and dispose of safely (if the apron is to be reused, place in a container with disinfectant).
+{:.figure .small .fixed}
 
 #### Step 2
 
-![Figure 3-12: If wearing protective overshoes, please remove them with your gloves still on. If wearing gumboots, see step 4.](images/3-12.svg)
-{:.half-page}
-
-Figure 3-12: If wearing protective overshoes, please remove them with your gloves still on. If wearing gumboots, see step 4.
-{:.figure-caption}
+> ![Figure 3-12: If wearing protective overshoes, please remove them with your gloves still on. If wearing gumboots, see step 4.](images/3-12.svg)
+> 
+> Figure 3-12: If wearing protective overshoes, please remove them with your gloves still on. If wearing gumboots, see step 4.
+{:.figure .small .fixed}
 
 #### Step 3
 
-![Figure 3-13: Remove gown and gloves and roll inside-out and dispose of safely.](images/3-13.svg)
-{:.half-page}
-
-Figure 3-13: Remove gown and gloves and roll inside-out and dispose of safely.
-{:.figure-caption}
+> ![Figure 3-13: Remove gown and gloves and roll inside-out and dispose of safely.](images/3-13.svg)
+> 
+> Figure 3-13: Remove gown and gloves and roll inside-out and dispose of safely.
+{:.figure .small .fixed}
 
 #### Step 4
 
-![Figure 3-14: If wearing rubber boots, remove them (ideally using the boot remover) without touching them with your hands. Place the removed boots into a container with disinfectant.](images/3-14.svg)
-{:.half-page}
-
-Figure 3-14: If wearing rubber boots, remove them (ideally using the boot remover) without touching them with your hands. Place the removed boots into a container with disinfectant.
-{:.figure-caption}
+> ![Figure 3-14: If wearing rubber boots, remove them (ideally using the boot remover) without touching them with your hands. Place the removed boots into a container with disinfectant.](images/3-14.svg)
+> 
+> Figure 3-14: If wearing rubber boots, remove them (ideally using the boot remover) without touching them with your hands. Place the removed boots into a container with disinfectant.
+{:.figure .small .fixed}
 
 #### Step 5
 
-![Figure 3-15: Perform hand hygiene.](images/3-15.svg)
-{:.half-page}
-
-Figure 3-15: Perform hand hygiene.
-{:.figure-caption}
+> ![Figure 3-15: Perform hand hygiene.](images/3-15.svg)
+> 
+> Figure 3-15: Perform hand hygiene.
+{:.figure .small .fixed}
 
 #### Step 6
 
-![Figure 3-16: If wearing a head-covering, remove it now (from behind head).](images/3-16.svg)
-{:.half-page}
-
-Figure 3-16: If wearing a head-covering, remove it now (from behind head).
-{:.figure-caption}
+> ![Figure 3-16: If wearing a head-covering, remove it now (from behind head).](images/3-16.svg)
+> 
+> Figure 3-16: If wearing a head-covering, remove it now (from behind head).
+{:.figure .small .fixed}
 
 #### Step 7a
 
-![Figure 3-17: Remove face protection: Remove face shield or goggles (from behind head). Place eye protection in a separate container for reprocessing.](images/3-17.svg)
-{:.half-page}
-
-Figure 3-17: Remove face protection: Remove face shield or goggles (from behind head). Place eye protection in a separate container for reprocessing.
-{:.figure-caption}
+> ![Figure 3-17: Remove face protection: Remove face shield or goggles (from behind head). Place eye protection in a separate container for reprocessing.](images/3-17.svg)
+> 
+> Figure 3-17: Remove face protection: Remove face shield or goggles (from behind head). Place eye protection in a separate container for reprocessing.
+{:.figure .small .fixed}
 
 #### Step 7b
 
-![Figure 3-18: Remove face protection: Remove mask from behind head. When removing mask, untie the bottom string first and then the top string.](images/3-18.svg)
-{:.half-page}
-
-Figure 3-18: Remove face protection: Remove mask from behind head. When removing mask, untie the bottom string first and then the top string.
-{:.figure-caption}
+> ![Figure 3-18: Remove face protection: Remove mask from behind head. When removing mask, untie the bottom string first and then the top string.](images/3-18.svg)
+> 
+> Figure 3-18: Remove face protection: Remove mask from behind head. When removing mask, untie the bottom string first and then the top string.
+{:.figure .small .fixed}
 
 #### Step 8
 
-![Figure 3-19: Perform hand hygiene.](images/3-19.svg)
-{:.half-page}
-
-Figure 3-19: Perform hand hygiene.
-{:.figure-caption}
+> ![Figure 3-19: Perform hand hygiene.](images/3-19.svg)
+> 
+> Figure 3-19: Perform hand hygiene.
+{:.figure .small .fixed}
 
 > Healthcare workers must take extreme caution not to contaminate themselves with blood or body fluids while removing personal protective equipment.
 
@@ -459,23 +443,20 @@ All healthcare workers (whether local or foreign volunteers) remain at risk for 
 
 This has been a controversial issue particularly for healthcare workers returning home to non-Ebola affected regions of the world. If they have no symptoms, healthcare workers in some settings may be allowed to return to work immediately (since individuals are not infectious during incubation). As a minimum, healthcare workers should self-monitor for Ebola symptoms and fever during the 21 day incubation period post last Ebola exposure. As a precautionary measure, many health authorities have discouraged healthcare workers from using public transport and attending mass gatherings during the 21-day post exposure period. 
 
-![Figure 3-20: How to handwash](images/3-20.svg)
-{:.full-page}
+> ![Figure 3-20: How to handwash (adapted for low-data access from WHO/World Alliance for Patient Safety materials.)](images/3-20.svg)
+> 
+> Figure 3-20: How to handwash (adapted for low-data access from WHO/World Alliance for Patient Safety materials.)
+{:.figure .large}
 
-Figure 3-20: How to handwash
-{:.figure-caption}
+> ![Figure 3-21: How to handrub (adapted for low-data access from WHO/World Alliance for Patient Safety materials.)](images/3-21.svg)
+> 
+> Figure 3-21: How to handrub (adapted for low-data access from WHO/World Alliance for Patient Safety materials.)
+{:.figure .large}
 
-![Figure 3-21: How to handrub](images/3-21.svg)
-{:.full-page}
-
-Figure 3-21: How to handrub
-{:.figure-caption}
-
-![Figure 3-22: WHO 5 moments for hand hygiene](images/3-22.svg)
-{:.full-page}
-
-Figure 3-22: WHO 5 moments for hand hygiene
-{:.figure-caption}
+> ![Figure 3-22: WHO 5 moments for hand hygiene (adapted for low-data access from WHO/World Alliance for Patient Safety materials.)](images/3-22.svg)
+> 
+> Figure 3-22: WHO 5 moments for hand hygiene (adapted for low-data access from WHO/World Alliance for Patient Safety materials.)
+{:.figure .large}
 
 ## Case study 
 

--- a/ebola-prevention-and-control/4.md
+++ b/ebola-prevention-and-control/4.md
@@ -597,11 +597,10 @@ Table 4-3: Preferred workflow for an Ebola Treatment Unit
   </tbody>
 </table>
 
-![Figure 4-1: Preferred workflow for an Ebola Treatment Unit](images/4-1.svg)
-{:.keep-with-next}
-
-Figure 4-1: Preferred workflow for an Ebola Treatment Unit
-{:.figure-caption}
+> ![Figure 4-1: Preferred workflow for an Ebola Treatment Unit](images/4-1.svg)
+> 
+> Figure 4-1: Preferred workflow for an Ebola Treatment Unit
+{:.figure}
 
 ### 4-39 What is required for water supply?
 

--- a/ebola-prevention-and-control/6.md
+++ b/ebola-prevention-and-control/6.md
@@ -89,32 +89,32 @@ This is intended to guide a local producer in the actual preparation of the form
 > ![Figure 6-1: 10 litre glass or plastic bottles with screw-threaded stoppers](images/6-1.svg)
 > 
 > Figure 6-1: 10 litre glass or plastic bottles with screw-threaded stoppers
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-2: 50 litre plastic tanks (preferably in polypropylene or high-density polyethylene, translucent so as to see the liquid level](images/6-2.svg)
 > 
 > Figure 6-2: 50 litre plastic tanks (preferably in polypropylene or high-density polyethylene, translucent so as to see the liquid level
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-3: Stainless steel tanks with a capacity of 80-100 litres (for mixing without overflowing)](images/6-3.svg)
 > 
 > Figure 6-3: Stainless steel tanks with a capacity of 80-100 litres (for mixing without overflowing)
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-4: Wooden, plastic or metal paddles for mixing](images/6-4.svg)
 > 
 > Figure 6-4: Wooden, plastic or metal paddles for mixing
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-5: Measuring cylinders or measuring jugs](images/6-5.svg)
 > 
 > Figure 6-5: Measuring cylinders or measuring jugs
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-6: 100 ml and 500 ml plastic bottles with leak-proof tops](images/6-6.svg)
 > 
 > Figure 6-6: 100&nbsp;ml and 500&nbsp;ml plastic bottles with leak-proof tops
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-7: An alcoholmeter: the temperature scale is at the bottom and the ethanol concentration (percentage v/v and w/w) at the top](images/6-7.svg)
 > 
@@ -170,37 +170,37 @@ These can be prepared in 10 litre glass or plastic bottles with screw-threaded s
 > ![Figure 6-8: 1. The alcohol for the formula to be used is poured into the large bottle or tank up to the graduated mark.](images/6-8.svg)
 > 
 > Figure 6-8: 1. The alcohol for the formula to be used is poured into the large bottle or tank up to the graduated mark.
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-9: 2. Hydrogen peroxide is added using the measuring cylinder.](images/6-9.svg)
 > 
 > Figure 6-9: 2. Hydrogen peroxide is added using the measuring cylinder.
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-10: 3. Glycerol is added using a measuring cylinder. As glycerol is very viscous and sticks to the wall of the measuring cylinder, it should be rinsed with some sterile distilled or cold boiled water and then emptied into the bottle/tank.](images/6-10.svg)
 > 
 > Figure 6-10: 3. Glycerol is added using a measuring cylinder. As glycerol is very viscous and sticks to the wall of the measuring cylinder, it should be rinsed with some sterile distilled or cold boiled water and then emptied into the bottle/tank.
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-11: 4. The bottle/tank is then topped up to the 10 litre mark with sterile distilled or cold boiled water.](images/6-11.svg)
 > 
 > Figure 6-11: 4. The bottle/tank is then topped up to the 10 litre mark with sterile distilled or cold boiled water.
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-12: 5. The lid or screw cap is placed on the tank/bottle as soon as possible after preparation in order to prevent evaporation.](images/6-12.svg)
 > 
 > Figure 6-12: 5. The lid or screw cap is placed on the tank/bottle as soon as possible after preparation in order to prevent evaporation.
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-13: 6. The solution is mixed by shaking gently where appropriate or by using a paddle.](images/6-13.svg)
 > 
 > Figure 6-13: 6. The solution is mixed by shaking gently where appropriate or by using a paddle.
-{:.figure}
+{:.figure .small}
 
 > ![Figure 6-14: 7. Immediately divide up the solution into its final containers (e.g. 500 or 100 ml plastic bottles), and place the bottles in quarantine for 72 hours before use. This allows time for any spores present in the alcohol or the newly used bottles to be destroyed.](images/6-14.svg)
 > 
 > Figure 6-14: 7. Immediately divide up the solution into its final containers (e.g. 500 or 100 ml plastic bottles), and place the bottles in quarantine for 72 hours before use. This allows time for any spores present in the alcohol or the newly used bottles to be destroyed.
-{:.figure}
+{:.figure .small}
 
 **Final products: Formulation 1**
 {:.keep-with-next}

--- a/ebola-prevention-and-control/6.md
+++ b/ebola-prevention-and-control/6.md
@@ -86,40 +86,40 @@ This is intended to guide a local producer in the actual preparation of the form
 *	100&nbsp;ml and 500&nbsp;ml plastic bottles with leak-proof tops (6)
 *	An alcoholmeter: the temperature scale is at the bottom and the ethanol concentration (percentage v/v and w/w) at the top (7)
 
-![Figure 6-1: 10 litre glass or plastic bottles with screw-threaded stoppers](images/6-1.svg)
+> ![Figure 6-1: 10 litre glass or plastic bottles with screw-threaded stoppers](images/6-1.svg)
+> 
+> Figure 6-1: 10 litre glass or plastic bottles with screw-threaded stoppers
+{:.figure}
 
-Figure 6-1: 10 litre glass or plastic bottles with screw-threaded stoppers
-{:.figure-caption}
+> ![Figure 6-2: 50 litre plastic tanks (preferably in polypropylene or high-density polyethylene, translucent so as to see the liquid level](images/6-2.svg)
+> 
+> Figure 6-2: 50 litre plastic tanks (preferably in polypropylene or high-density polyethylene, translucent so as to see the liquid level
+{:.figure}
 
-![Figure 6-2: 50 litre plastic tanks (preferably in polypropylene or high-density polyethylene, translucent so as to see the liquid level](images/6-2.svg)
+> ![Figure 6-3: Stainless steel tanks with a capacity of 80-100 litres (for mixing without overflowing)](images/6-3.svg)
+> 
+> Figure 6-3: Stainless steel tanks with a capacity of 80-100 litres (for mixing without overflowing)
+{:.figure}
 
-Figure 6-2: 50 litre plastic tanks (preferably in polypropylene or high-density polyethylene, translucent so as to see the liquid level
-{:.figure-caption}
+> ![Figure 6-4: Wooden, plastic or metal paddles for mixing](images/6-4.svg)
+> 
+> Figure 6-4: Wooden, plastic or metal paddles for mixing
+{:.figure}
 
-![Figure 6-3: Stainless steel tanks with a capacity of 80-100 litres (for mixing without overflowing)](images/6-3.svg)
+> ![Figure 6-5: Measuring cylinders or measuring jugs](images/6-5.svg)
+> 
+> Figure 6-5: Measuring cylinders or measuring jugs
+{:.figure}
 
-Figure 6-3: Stainless steel tanks with a capacity of 80-100 litres (for mixing without overflowing)
-{:.figure-caption}
+> ![Figure 6-6: 100 ml and 500 ml plastic bottles with leak-proof tops](images/6-6.svg)
+> 
+> Figure 6-6: 100&nbsp;ml and 500&nbsp;ml plastic bottles with leak-proof tops
+{:.figure}
 
-![Figure 6-4: Wooden, plastic or metal paddles for mixing](images/6-4.svg)
-
-Figure 6-4: Wooden, plastic or metal paddles for mixing
-{:.figure-caption}
-
-![Figure 6-5: Measuring cylinders or measuring jugs](images/6-5.svg)
-
-Figure 6-5: Measuring cylinders or measuring jugs
-{:.figure-caption}
-
-![Figure 6-6: 100 ml and 500 ml plastic bottles with leak-proof tops](images/6-6.svg)
-
-Figure 6-6: 100&nbsp;ml and 500&nbsp;ml plastic bottles with leak-proof tops
-{:.figure-caption}
-
-![Figure 6-7: An alcoholmeter: the temperature scale is at the bottom and the ethanol concentration (percentage v/v and w/w) at the top](images/6-7.svg)
-
-Figure 6-7: An alcoholmeter: the temperature scale is at the bottom and the ethanol concentration (percentage v/v and w/w) at the top
-{:.figure-caption}
+> ![Figure 6-7: An alcoholmeter: the temperature scale is at the bottom and the ethanol concentration (percentage v/v and w/w) at the top](images/6-7.svg)
+> 
+> Figure 6-7: An alcoholmeter: the temperature scale is at the bottom and the ethanol concentration (percentage v/v and w/w) at the top
+{:.figure}
 
 #### Note
 
@@ -167,43 +167,44 @@ These can be prepared in 10 litre glass or plastic bottles with screw-threaded s
 **Step-by-step preparation**
 {:.keep-with-next}
 
-![Figure 6-8: 1. The alcohol for the formula to be used is poured into the large bottle or tank up to the graduated mark.](images/6-8.svg)
+> ![Figure 6-8: 1. The alcohol for the formula to be used is poured into the large bottle or tank up to the graduated mark.](images/6-8.svg)
+> 
+> Figure 6-8: 1. The alcohol for the formula to be used is poured into the large bottle or tank up to the graduated mark.
+{:.figure}
 
-Figure 6-8: 1. The alcohol for the formula to be used is poured into the large bottle or tank up to the graduated mark.
-{:.figure-caption}
+> ![Figure 6-9: 2. Hydrogen peroxide is added using the measuring cylinder.](images/6-9.svg)
+> 
+> Figure 6-9: 2. Hydrogen peroxide is added using the measuring cylinder.
+{:.figure}
 
-![Figure 6-9: 2. Hydrogen peroxide is added using the measuring cylinder.](images/6-9.svg)
+> ![Figure 6-10: 3. Glycerol is added using a measuring cylinder. As glycerol is very viscous and sticks to the wall of the measuring cylinder, it should be rinsed with some sterile distilled or cold boiled water and then emptied into the bottle/tank.](images/6-10.svg)
+> 
+> Figure 6-10: 3. Glycerol is added using a measuring cylinder. As glycerol is very viscous and sticks to the wall of the measuring cylinder, it should be rinsed with some sterile distilled or cold boiled water and then emptied into the bottle/tank.
+{:.figure}
 
-Figure 6-9: 2. Hydrogen peroxide is added using the measuring cylinder.
-{:.figure-caption}
+> ![Figure 6-11: 4. The bottle/tank is then topped up to the 10 litre mark with sterile distilled or cold boiled water.](images/6-11.svg)
+> 
+> Figure 6-11: 4. The bottle/tank is then topped up to the 10 litre mark with sterile distilled or cold boiled water.
+{:.figure}
 
-![Figure 6-10: 3. Glycerol is added using a measuring cylinder. As glycerol is very viscous and sticks to the wall of the measuring cylinder, it should be rinsed with some sterile distilled or cold boiled water and then emptied into the bottle/tank.](images/6-10.svg)
+> ![Figure 6-12: 5. The lid or screw cap is placed on the tank/bottle as soon as possible after preparation in order to prevent evaporation.](images/6-12.svg)
+> 
+> Figure 6-12: 5. The lid or screw cap is placed on the tank/bottle as soon as possible after preparation in order to prevent evaporation.
+{:.figure}
 
-Figure 6-10: 3. Glycerol is added using a measuring cylinder. As glycerol is very viscous and sticks to the wall of the measuring cylinder, it should be rinsed with some sterile distilled or cold boiled water and then emptied into the bottle/tank.
-{:.figure-caption}
+> ![Figure 6-13: 6. The solution is mixed by shaking gently where appropriate or by using a paddle.](images/6-13.svg)
+> 
+> Figure 6-13: 6. The solution is mixed by shaking gently where appropriate or by using a paddle.
+{:.figure}
 
-![Figure 6-11: 4. The bottle/tank is then topped up to the 10 litre mark with sterile distilled or cold boiled water.](images/6-11.svg)
-
-Figure 6-11: 4. The bottle/tank is then topped up to the 10 litre mark with sterile distilled or cold boiled water.
-{:.figure-caption}
-
-![Figure 6-12: 5. The lid or screw cap is placed on the tank/bottle as soon as possible after preparation in order to prevent evaporation.](images/6-12.svg)
-
-Figure 6-12: 5. The lid or screw cap is placed on the tank/bottle as soon as possible after preparation in order to prevent evaporation.
-{:.figure-caption}
-
-![Figure 6-13: 6. The solution is mixed by shaking gently where appropriate or by using a paddle.](images/6-13.svg)
-
-Figure 6-13: 6. The solution is mixed by shaking gently where appropriate or by using a paddle.
-{:.figure-caption}
-
-![Figure 6-14: 7. Immediately divide up the solution into its final containers (e.g. 500 or 100 ml plastic bottles), and place the bottles in quarantine for 72 hours before use. This allows time for any spores present in the alcohol or the newly used bottles to be destroyed.](images/6-14.svg)
-
-Figure 6-14: 7. Immediately divide up the solution into its final containers (e.g. 500 or 100 ml plastic bottles), and place the bottles in quarantine for 72 hours before use. This allows time for any spores present in the alcohol or the newly used bottles to be destroyed.
-{:.figure-caption}
+> ![Figure 6-14: 7. Immediately divide up the solution into its final containers (e.g. 500 or 100 ml plastic bottles), and place the bottles in quarantine for 72 hours before use. This allows time for any spores present in the alcohol or the newly used bottles to be destroyed.](images/6-14.svg)
+> 
+> Figure 6-14: 7. Immediately divide up the solution into its final containers (e.g. 500 or 100 ml plastic bottles), and place the bottles in quarantine for 72 hours before use. This allows time for any spores present in the alcohol or the newly used bottles to be destroyed.
+{:.figure}
 
 **Final products: Formulation 1**
 {:.keep-with-next}
+
 Final concentrations:
 
 *	Ethanol 80% (v/v)
@@ -212,6 +213,7 @@ Final concentrations:
 
 **Final products: Formulation 2**
 {:.keep-with-next}
+
 Final concentrations:
 
 *	Isopropyl alcohol 75% (v/v)
@@ -223,15 +225,15 @@ Final concentrations:
 1.	Pre-production analysis should be made every time an analysis certificate is not available to guarantee the titration of alcohol (i.e. local production). Verify the alcohol concentration with the alcoholmeter and make the necessary adjustments in volume in the preparation formulation to obtain the final recommended concentration.
 2.	Post-production analysis is mandatory if either ethanol or an isopropanol solution is used. Use the alcoholmeter to control the alcohol concentration of the final use solution. The accepted limits should be fixed to +- 5% of the target concentration (75%-85% for ethanol).
 
-![Figure 6-15: Alcoholmeter in measuring cylinder showing 80%](images/6-15.svg)
+> ![Figure 6-15: Alcoholmeter in measuring cylinder showing 80%](images/6-15.svg)
+> 
+> Figure 6-15: Alcoholmeter in measuring cylinder showing 80%
+{:.figure}
 
-Figure 6-15: Alcoholmeter in measuring cylinder showing 80%
-{:.figure-caption}
-
-![Figure 6-16: Alcoholmeter in measuring cylinder showing 75%](images/6-16.svg)
-
-Figure 6-16: Alcoholmeter in measuring cylinder showing 75% (Source: Guide to local production: WHO-recommended Handrub Formulations)
-{:.figure-caption}
+> ![Figure 6-16: Alcoholmeter in measuring cylinder showing 75%](images/6-16.svg)
+> 
+> Figure 6-16: Alcoholmeter in measuring cylinder showing 75% (Source: Guide to local production: WHO-recommended Handrub Formulations)
+{:.figure}
 
 ## Infection Control Readiness Checklist: Ebola Virus Disease
 

--- a/infection-prevention-and-control/2.md
+++ b/infection-prevention-and-control/2.md
@@ -59,10 +59,10 @@ Most bacteria are easily recognisable because they have particular shapes, stain
 
 The shape of the bacteria varies for different families, for example they can appear round (cocci), rod-like (bacilli), spiral (spirochetes) or curved (vibrios). 
 
-![Figure 2-1: Basic shapes and grouping patterns of bacteria](images/2-1.svg)
-
-Figure 2-1: Basic shapes and grouping patterns of bacteria
-{:.figure-caption}
+> ![Figure 2-1: Basic shapes and grouping patterns of bacteria](images/2-1.svg)
+> 
+> Figure 2-1: Basic shapes and grouping patterns of bacteria
+{:.figure}
 
 ### 2-7 How can bacteria be classified by their staining pattern?
 
@@ -105,10 +105,10 @@ Bacteria can also be classified by their growth requirements such as the need fo
 
 Bacteria are single-cell organisms that have all the structures needed for their survival and replication. All bacteria are surrounded by a rigid outer cell wall, which gives them their shape (Gram-positive bacteria have thicker cell walls than Gram-negative bacteria). The cell wall allows some substances in and out of bacteria through tiny channels (porins). Some bacteria have projections from the cell wall called pili and flagella. Pili help with bacterial attachment to host cells, while flagella allow bacteria to move. A thin membrane called the cytoplasmic membrane runs inside the cell wall and holds together all the cell contents. Important cell contents include the bacterial genetic material (DNA) and ribosomes (which act as factories producing more genetic material).
 
-![Figure 2-2: The structure of bacteria](images/2-2.svg)
-
-Figure 2-2: The structure of bacteria
-{:.figure-caption}
+> ![Figure 2-2: The structure of bacteria](images/2-2.svg)
+> 
+> Figure 2-2: The structure of bacteria
+{:.figure}
 
 ### 2-13 What is the pattern of bacterial growth?
 
@@ -131,10 +131,10 @@ Viruses can only survive within host (human, animal or plant) cells, usually cel
 
 Viruses are categorised both by their genetic make-up (single- or double-stranded, RNA or DNA) and their shape. The virus’ shape (icosahedral, helical and complex) is determined by its nucleocapsid structure, which is a combination of viral nucleic acid and capsid (the outer shell). In some viruses the nucleocapsid is covered by an outer membrane (known as an envelope), whereas others are “naked” or non-enveloped. Viruses without an envelope are more difficult to destroy or remove by disinfection.  
 
-![Figure 2-3: The structure of a virus](images/2-3.svg)
-
-Figure 2-3: The structure of a virus
-{:.figure-caption}
+> ![Figure 2-3: The structure of a virus](images/2-3.svg)
+> 
+> Figure 2-3: The structure of a virus
+{:.figure}
 
 ### 2-16 How are parasites classified?
 
@@ -229,10 +229,10 @@ For example, TB remains suspended in the air as aerosols (tiny particles contain
 For example, TB bacilli suspended in the air may be breathed into the lungs of a person in the same room as the 
 TB patient.
 
-![Figure 2-4: The chain of infection](images/2-4.svg)
-
-Figure 2-4: The chain of infection
-{:.figure-caption}
+> ![Figure 2-4: The chain of infection](images/2-4.svg)
+> 
+> Figure 2-4: The chain of infection
+{:.figure}
 
 ### 2-19 How do micro-organisms enter the human body?
 

--- a/infection-prevention-and-control/3.md
+++ b/infection-prevention-and-control/3.md
@@ -67,10 +67,10 @@ For example, priority interventions for your facility: training of all staff in 
 
 For example, keep records of all NSI before, during and after the interventions, monitor how well the interventions were implemented, improve policies and re-train staff periodically. 
 
-![Figure 3-1: Risk assessment in IPC](images/3-1.svg)
-
-Figure 3-1: Risk assessment in IPC
-{:.figure-caption}
+> ![Figure 3-1: Risk assessment in IPC](images/3-1.svg)
+> 
+> Figure 3-1: Risk assessment in IPC
+{:.figure}
 
 ### 3-3 When should risk assessment in IPC be performed? 
 
@@ -152,10 +152,10 @@ Table 3-1: Further details on standard precautions
 
 > Standard precautions should be applied to all patients in all circumstances, whether or not they are known to pose an infection risk.
 
-![Figure 3-2: Standard precautions](images/3-2.svg)
-
-Figure 3-2: Standard precautions
-{:.figure-caption}
+> ![Figure 3-2: Standard precautions](images/3-2.svg)
+> 
+> Figure 3-2: Standard precautions
+{:.figure}
 
 ### 3-11 What are transmission-based precautions? 
 
@@ -187,20 +187,20 @@ Table 3-2: Transmission-based precautions for the three major routes of transmis
 
 > Transmission-based precautions are applied in addition to standard precautions based on a pathogen’s route/s of transmission. 
 
-![Figure 3-3: Contact precautions](images/3-3.svg)
+> ![Figure 3-3: Contact precautions](images/3-3.svg)
+> 
+> Figure 3-3: Contact precautions (Adapted from *Infection Prevention and Control Manual*, Tygerberg Academic Hospital, Cape Town, South Africa, 2012)
+{:.figure}
 
-Figure 3-3: Contact precautions (Adapted from *Infection Prevention and Control Manual*, Tygerberg Academic Hospital, Cape Town, South Africa, 2012)
-{:.figure-caption}
+> ![Figure 3-4: Droplet precautions](images/3-4.svg)
+> 
+> Figure 3-4: Droplet precautions (Adapted from *Infection Prevention and Control Manual*, Tygerberg Academic Hospital, Cape Town, South Africa, 2012)
+{:.figure}
 
-![Figure 3-4: Droplet precautions](images/3-4.svg)
-
-Figure 3-4: Droplet precautions (Adapted from *Infection Prevention and Control Manual*, Tygerberg Academic Hospital, Cape Town, South Africa, 2012)
-{:.figure-caption}
-
-![Figure 3-5: Airborne precautions](images/3-5.svg)
-
-Figure 3-5: Airborne precautions (Adapted from *Infection Prevention and Control Manual*, Tygerberg Academic Hospital, Cape Town, South Africa, 2012)
-{:.figure-caption}
+> ![Figure 3-5: Airborne precautions](images/3-5.svg)
+> 
+> Figure 3-5: Airborne precautions (Adapted from *Infection Prevention and Control Manual*, Tygerberg Academic Hospital, Cape Town, South Africa, 2012)
+{:.figure}
 
 ### 3-12 What are procedure-based precautions?
 
@@ -218,10 +218,9 @@ Personal protective equipment (PPE) includes any item designed to protect health
 
 PPE is required for most clinical procedures and aseptic tasks. PPE is also required for domestic, waste management and sterile services department staff. The figure below indicates which PPE are required for certain commonly performed tasks and procedures.
 
-|----------------------------+-----------------+-------------------+-----------------+-----------------+-----------------------|
-|         Procedure          | Hand hygiene    |      Gloves       |     Aprons      | Masks           |      Eye covers       |
-|                            |(images/3-6A.svg)|(images/3-6B.svg)  |(images/3-6C.svg)|(images/3-6D.svg)|(images/3-6E.svg)      |
-|----------------------------+-----------------+-------------------+-----------------+-----------------+-----------------------|
+|         Procedure          | Hand hygiene                    |      Gloves                 |     Aprons                 | Masks                     |      Eye covers                     |
+|                            |![Hand hygiene](images/3-6A.svg) | ![Gloves](images/3-6B.svg)  | ![Aprons](images/3-6C.svg) | ![Masks](images/3-6D.svg) | ![Eye covers](images/3-6E.svg)      |
+|----------------------------+---------------------------------+-----------------------------+----------------------------+---------------------------+-------------------------------------|
 | IV cannulation             | ✓               | ✓                 |                 |                 |                       |
 | Wound dressing             | ✓               | Aseptic technique |                 |                 |                       |
 | Insertion of NG tube       | ✓               | ✓                 |                 |                 |                       |

--- a/infection-prevention-and-control/4.md
+++ b/infection-prevention-and-control/4.md
@@ -88,10 +88,10 @@ The World Health Organization (WHO) has identified five times when hand hygiene 
 
 The last of the five moments, after contact with the patient’s surroundings, is the hand hygiene opportunity that is most often missed or not clearly understood by healthcare workers. The healthcare environment includes anything in the immediate patient’s surroundings (e.g. heart/saturation monitors, patient charts, bedside tables). Healthcare workers should take particular care to perform hand hygiene after touching these objects or surfaces.
 
-![Figure 4-1: 5 moments for hand hygiene](images/4-1.svg)
-
-Figure 4-1: 5 moments for hand hygiene
-{:.figure-caption}
+> ![Figure 4-1: 5 moments for hand hygiene](images/4-1.svg)
+> 
+> Figure 4-1: 5 moments for hand hygiene
+{:.figure .large}
 
 > The “WHO Five Moments for Hand Hygiene” are a reminder of when hand hygiene should be performed by healthcare workers.
 
@@ -121,15 +121,15 @@ Some healthcare workers use gloves to avoid having to perform hand hygiene. Besi
 
 > It is not acceptable to use gloves to replace hand hygiene since micro-organisms can still be transferred through pores in the gloves.
 
-![Figure 4-2: How to handwash](images/4-2.svg)
+> ![Figure 4-2: How to handwash](images/4-2.svg)
+> 
+> Figure 4-2: How to handwash
+{:.figure .large}
 
-Figure 4-2: How to handwash
-{:.figure-caption}
-
-![Figure 4-3: How to handrub](images/4-3.svg)
-
-Figure 4-3: How to handrub
-{:.figure-caption}
+> ![Figure 4-3: How to handrub](images/4-3.svg)
+> 
+> Figure 4-3: How to handrub
+{:.figure .large}
 
 ### 4-17 When should gloves be used?
 

--- a/infection-prevention-and-control/6.md
+++ b/infection-prevention-and-control/6.md
@@ -217,10 +217,10 @@ Decontamination includes some or all of the following steps:
 
 Different micro-organisms have differing levels of susceptibility to destruction. Some, like viruses, most bacteria and fungi are relatively easy to kill. Others, like mycobacteria (TB) and spores (*Clostridium difficile*) are relatively resistant to killing. That is why it is important to know which micro-organisms need to be destroyed when selecting the appropriate method for decontaminating a particular device.  
 
-![Figure 6-1: Most resistant to least resistant micro-organisms](images/6-1.svg)
-
-Figure 6-1: Most resistant to least resistant micro-organisms
-{:.figure-caption}
+> ![Figure 6-1: Most resistant to least resistant micro-organisms](images/6-1.svg)
+> 
+> Figure 6-1: Most resistant to least resistant micro-organisms
+{:.figure}
 
 ### 6-24 Which medical devices should be decontaminated?
 

--- a/infection-prevention-and-control/9.md
+++ b/infection-prevention-and-control/9.md
@@ -317,25 +317,25 @@ An antimicrobial prescription chart is a dedicated (stand-alone) chart that cont
 
 An example of the antimicrobial prescription chart used by the South African Antibiotic Stewardship Programme (SAASP) can be seen in Figure 9-1.
 
-![Figure 9-1a: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP](images/9-1a.svg)
+> ![Figure 9-1a: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP](images/9-1a.svg)
+> 
+> Figure 9-1a: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP
+{:.figure}
 
-Figure 9-1a: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP
-{:.figure-caption}
+> ![Figure 9-1b: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued](images/9-1b.svg)
+> 
+> Figure 9-1b: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued
+{:.figure}
 
-![Figure 9-1b: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued](images/9-1b.svg)
+> ![Figure 9-1c: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued](images/9-1c.svg)
+> 
+> Figure 9-1c: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued
+{:.figure}
 
-Figure 9-1b: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued
-{:.figure-caption}
-
-![Figure 9-1c: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued](images/9-1c.svg)
-
-Figure 9-1c: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued
-{:.figure-caption}
-
-![Figure 9-1d: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued](images/9-1d.svg)
-
-Figure 9-1d: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued
-{:.figure-caption}
+> ![Figure 9-1d: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued](images/9-1d.svg)
+> 
+> Figure 9-1d: Antimicrobial prescription chart, developed and produced by the South African Antibiotic Stewardship Programme (SAASP), reproduced by kind permission of  Dr Marc Mendelson and the SAASP continued
+{:.figure}
 
 ### 9-38 What is an antimicrobial stewardship ward round?
 

--- a/intrapartum-care/1.md
+++ b/intrapartum-care/1.md
@@ -65,10 +65,10 @@ All the maternal observations must be carefully recorded on the partogram.
 
 > All the observations of every mother in the first stage of labour must be recorded on a partogram.
 
-![Figure 1-1: Recording maternal observations on the partogram](images/1-1.svg)
-
-Figure 1-1: Recording maternal observations on the partogram
-{:.figure-caption}
+> ![Figure 1-1: Recording maternal observations on the partogram](images/1-1.svg)
+> 
+> Figure 1-1: Recording maternal observations on the partogram
+{:.figure}
 
 ### 1-8 How should each observation be assessed?
 

--- a/intrapartum-care/2.md
+++ b/intrapartum-care/2.md
@@ -159,10 +159,10 @@ Note
 
 Early decelerations are characterised by a slowing of the fetal heart rate starting at the beginning of the contraction, and returning to normal by the end of the contraction. Early decelerations are usually due to compression of the fetal head which causes the heart rate to slow during the contraction.
 
-![Figure 2-1: An early deceleration](images/2-1.svg)
-
-Figure 2-1: An early deceleration
-{:.figure-caption}
+> ![Figure 2-1: An early deceleration](images/2-1.svg)
+> 
+> Figure 2-1: An early deceleration
+{:.figure}
 
 ### 2-17 What is the significance of early decelerations?
 
@@ -180,10 +180,10 @@ A late deceleration is a slowing of the fetal heart rate during a contraction, w
 Note
 :	When using a cardiotocograph, a late deceleration is diagnosed when the lowest point of the deceleration occurs 30 seconds or more after the peak of the contraction.
 
-![Figure 2-2: A late deceleration](images/2-2.svg)
-
-Figure 2-2: A late deceleration
-{:.figure-caption}
+> ![Figure 2-2: A late deceleration](images/2-2.svg)
+> 
+> Figure 2-2: A late deceleration
+{:.figure}
 
 ### 2-19 What is the significance of late decelerations?
 
@@ -200,10 +200,10 @@ Variable decelerations are not easy to recognise with a fetal stethoscope or dop
 Note
 :	Variable decelerations accompanied by loss of variability of the fetal heart rate may indicate fetal distress. Variable decelerations with good variability is reassuring.
 
-![Figure 2-3: Variable decelerations](images/2-3.svg)
-
-Figure 2-3: Variable decelerations
-{:.figure-caption}
+> ![Figure 2-3: Variable decelerations](images/2-3.svg)
+> 
+> Figure 2-3: Variable decelerations
+{:.figure}
 
 ### 2-21 What is a baseline tachycardia?
 
@@ -350,10 +350,10 @@ The liquor findings should be recorded when:
 1.	A vaginal examination is done.
 1.	A change in the liquor findings is noticed, e.g. if the liquor becomes meconium stained.
 
-![Figure 2-4: Recording fetal observations on the partogram](images/2-4.svg)
-
-Figure 2-4: Recording fetal observations on the partogram
-{:.figure-caption}
+> ![Figure 2-4: Recording fetal observations on the partogram](images/2-4.svg)
+> 
+> Figure 2-4: Recording fetal observations on the partogram
+{:.figure}
 
 ## Case study 1
 

--- a/intrapartum-care/3.md
+++ b/intrapartum-care/3.md
@@ -89,10 +89,10 @@ A partogram is a chart on which the progress of labour over time can be presente
 
 An example of a partogram is shown in figure 3-1.
 
-![Figure 3-1: An example of a partogram](images/3-1.svg)
-
-Figure 3-1: An example of a partogram
-{:.figure-caption}
+> ![Figure 3-1: An example of a partogram](images/3-1.svg)
+> 
+> Figure 3-1: An example of a partogram
+{:.figure}
 
 ### 3-8 What is the first oblique line on the partogram called?
 

--- a/intrapartum-care/3a.md
+++ b/intrapartum-care/3a.md
@@ -71,10 +71,10 @@ It is also important to know the presentation of the fetus. The normal presentat
 
 If the presentation is cephalic, it is sometimes possible when palpating the abdomen to determine the presenting part of the fetal head (vertex, face or brow). Figure 3A-1 indicates some features that can assist you in determining the presentation.
 
-![Figure 3A-1: Vertex, face and brow presentations](images/3a-1.svg)
-
-Figure 3A-1: Vertex, face and brow presentations
-{:.figure-caption}
+> ![Figure 3A-1: Vertex, face and brow presentations](images/3a-1.svg)
+> 
+> Figure 3A-1: Vertex, face and brow presentations
+{:.figure}
 
 ### H. Descent and engagement of the head
 
@@ -95,10 +95,10 @@ Note
 
 > Descent and engagement of the head are assessed on abdominal and not on vaginal examination.
 
-![Figure 3A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/3a-2.svg)
-
-Figure 3A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis
-{:.figure-caption}
+> ![Figure 3A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/3a-2.svg)
+> 
+> Figure 3A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis
+{:.figure}
 
 ### I. Hardness and tenderness of the uterus
 
@@ -133,10 +133,10 @@ Contractions can be felt by placing a hand on the abdomen and feeling when the u
 2.	Contractions lasting 20–40 seconds (‘moderate contractions’)
 3.	Contractions lasting more than 40 seconds (‘strong contractions’).
 
-![Figure 3A-3: Method of grading the duration of uterine contractions for recording on the partogram](images/3a-3.svg)
-
-Figure 3A-3: Method of grading the duration of uterine contractions for recording on the partogram
-{:.figure-caption}
+> ![Figure 3A-3: Method of grading the duration of uterine contractions for recording on the partogram](images/3a-3.svg)
+> 
+> Figure 3A-3: Method of grading the duration of uterine contractions for recording on the partogram
+{:.figure}
 
 ### L. Grading the frequency duration of contractions
 

--- a/intrapartum-care/3b.md
+++ b/intrapartum-care/3b.md
@@ -92,10 +92,10 @@ Dilatation must be assessed in centimetres, and is best measured by comparing th
 1.	If the cervix is very thin, it may be difficult to feel, and the woman may be said to be fully dilated, when in fact she is not.
 1.	When feeling the rim of the cervix, it is easy to stretch it, or pass the fingers through the cervix and feel the rim with the side of the fingers. Both of these methods cause the recording of dilatation to be more than it really is. The correct method is to place the tips of the fingers on the edges of the cervix.
 
-![Figure 3B-1: The correct method of measuring cervical dilatation](images/3b-1.svg)
-
-Figure 3B-1: The correct method of measuring cervical dilatation
-{:.figure-caption}
+> ![Figure 3B-1: The correct method of measuring cervical dilatation](images/3b-1.svg)
+> 
+> Figure 3B-1: The correct method of measuring cervical dilatation
+{:.figure}
 
 ## The membranes and liquor
 
@@ -130,10 +130,10 @@ The presenting part is usually the head but may be the breech, the arm, or the s
 
 1.	*Features of an occiput presentation*. The posterior fontanelle is normally felt. It is a small triangular space. In contrast, the anterior fontanelle is diamond shaped. If the head is well flexed, the anterior fontanelle will not be felt. If the anterior fontanelle can be easily felt, the head is deflexed.
 
-	![Figure 3B-2: Features of an occiput presentation](images/3b-2.svg)
-	
-	Figure 3B-2: Features of an occiput presentation
-	{:.figure-caption}
+	> ![Figure 3B-2: Features of an occiput presentation](images/3b-2.svg)
+	> 
+	> Figure 3B-2: Features of an occiput presentation
+	{:.figure .fixed}
 
 1.	*Features of a face presentation*. On abdominal examination the presenting part is the head. However, on vaginal examination:
 	*	Instead of a firm skull, something soft is felt.
@@ -142,27 +142,27 @@ The presenting part is usually the head but may be the breech, the arm, or the s
 	*	The orbital ridges above the eyes can be felt.
 	*	The ears may be felt.
 	
-	![Figure 3B-3: Features of a face presentation](images/3b-3.svg)
-	
-	Figure 3B-3: Features of a face presentation
-	{:.figure-caption}
+	> ![Figure 3B-3: Features of a face presentation](images/3b-3.svg)
+	> 
+	> Figure 3B-3: Features of a face presentation
+	{:.figure .fixed}
 	
 1.	*Features of a brow presentation*. The presenting part is high. The anterior fontanelle felt is on one side of the pelvis, the root of the nose on the other side, and the orbital ridges may be felt laterally. If the presenting part is not the head, it could be either a breech or a shoulder.
 	
-	![Figure 3B-4: Features of a brow presentation](images/3b-4.svg)
-	
-	Figure 3B-4: Features of a brow presentation
-	{:.figure-caption}
+	> ![Figure 3B-4: Features of a brow presentation](images/3b-4.svg)
+	> 
+	> Figure 3B-4: Features of a brow presentation
+	{:.figure .fixed}
 	
 1.	*Features of a breech presentation*. On abdominal examination the presenting part is the breech (soft and triangular). On vaginal examination:
 	*	Instead of a firm skull, something soft is felt.
 	*	The anus does not have gum margins.
 	*	The anus and the ischial tuberosities form a straight line.
 	
-	![Figure 3B-5: Features of a breech presentation](images/3b-5.svg)
-	
-	Figure 3B-5: Features of a breech presentation
-	{:.figure-caption}
+	> ![Figure 3B-5: Features of a breech presentation](images/3b-5.svg)
+	> 
+	> Figure 3B-5: Features of a breech presentation
+	{:.figure .fixed}
 	
 1.	*Features of a shoulder presentation*. On abdominal examination the lie will be transverse or oblique. Features of a shoulder presentation on vaginal examination will be quite easy if the arm has prolapsed. The shoulder is not always that easy to identify, unless the arm can be felt. The presenting part is usually high.
 
@@ -178,10 +178,10 @@ The point of reference (or denominator) is:
 
 For example, if the posterior fontanelle (i.e. the fetal occiput) in a vertex presentation points upwards (anterior) and towards the mother’s left side the position of the presenting part is called a left occipito-anterior position.
 
-![Figure 3B-6: Examples of the position of the presenting part with the patient lying on her back](images/3b-6.svg)
-
-Figure 3B-6: Examples of the position of the presenting part with the patient lying on her back
-{:.figure-caption}
+> ![Figure 3B-6: Examples of the position of the presenting part with the patient lying on her back](images/3b-6.svg)
+> 
+> Figure 3B-6: Examples of the position of the presenting part with the patient lying on her back
+{:.figure}
 
 ### J. Determining the descent and engagement of the head
 
@@ -230,10 +230,10 @@ Start with the sacral promontory and follow the curve of the sacrum down the mid
 1.	An adequate pelvis: The promontory cannot be easily palpated, the sacrum is well curved and the coccyx cannot be felt.
 1.	A small pelvis: The promontory is easily palpated and prominent, the sacrum is straight and the coccyx is prominent and/or fixed.
 
-![Figure 3B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory](images/3b-7.svg)
-
-Figure 3B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory
-{:.figure-caption}
+> ![Figure 3B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory](images/3b-7.svg)
+> 
+> Figure 3B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory
+{:.figure}
 
 *Step 2. The ischial spines and sacrospinous ligaments*
 
@@ -249,10 +249,10 @@ Put two examining fingers, with the palm of the hand facing upwards, behind the 
 1.	An adequate pelvis: The retropubic area is flat.
 1.	A small pelvis: The retropubic area is angulated.
 
-![Figure 3B-8: The brim of the pelvis](images/3b-8.svg)
-
-Figure 3B-8: The brim of the pelvis
-{:.figure-caption}
+> ![Figure 3B-8: The brim of the pelvis](images/3b-8.svg)
+> 
+> Figure 3B-8: The brim of the pelvis
+{:.figure}
 
 *Step 4. The subpubic angle and intertuberous diameter*
 
@@ -261,7 +261,7 @@ To measure the subpubic angle, the examining fingers are turned so that the palm
 1.	An adequate pelvis: The subpubic angle allows three fingers (i.e. an angle of about 90 degrees) and the intertuberous diameter allows four knuckles.
 1.	A small pelvis: The subpubic angle allows only two fingers (i.e. an angle of about 60 degrees) and the intertuberous diameter allows only three knuckles.
 
-![Figure 3B-9: The pelvic outlet](images/3b-9.svg)
-
-Figure 3B-9: The pelvic outlet
-{:.figure-caption}
+> ![Figure 3B-9: The pelvic outlet](images/3b-9.svg)
+> 
+> Figure 3B-9: The pelvic outlet
+{:.figure}

--- a/intrapartum-care/3c.md
+++ b/intrapartum-care/3c.md
@@ -21,10 +21,10 @@ When you have completed this skills workshop you should be able to:
 
 The condition of the mother, the condition of the fetus, and the progress of labour are recorded on the partogram.
 
-![Figure 3C-1: An example of a partogram](images/3c-1.svg)
-
-Figure 3C-1: An example of a partogram
-{:.figure-caption}
+> ![Figure 3C-1: An example of a partogram](images/3c-1.svg)
+> 
+> Figure 3C-1: An example of a partogram
+{:.figure}
 
 ## Recording the condition of the mother
 
@@ -38,10 +38,10 @@ The maternal blood pressure, pulse and temperature should be recorded on the par
 1.	Protein is recorded as 0 to 4+.
 1.	Ketones are recorded as 0 to 4+.
 
-![Figure 3C-2: Recording maternal blood pressure, pulse, temperature and urine results on the partogram](images/3c-2.svg)
-
-Figure 3C-2: Recording maternal blood pressure, pulse, temperature and urine results on the partogram
-{:.figure-caption}
+> ![Figure 3C-2: Recording maternal blood pressure, pulse, temperature and urine results on the partogram](images/3c-2.svg)
+> 
+> Figure 3C-2: Recording maternal blood pressure, pulse, temperature and urine results on the partogram
+{:.figure}
 
 ## Recording the condition of the fetus
 
@@ -69,10 +69,10 @@ The recordings should be made:
 1.	At the time of each vaginal examination.
 1.	Whenever a change in the liquor is noted, e.g. when the membranes rupture or if the woman starts to drain meconium-stained liquor after having had clear liquor before.
 
-![Figure 3C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram](images/3c-3.svg)
-
-Figure 3C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram
-{:.figure-caption}
+> ![Figure 3C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram](images/3c-3.svg)
+> 
+> Figure 3C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram
+{:.figure}
 
 ## Recording the progress of labour
 
@@ -96,10 +96,10 @@ The position of the fetal head is recorded by marking the ‘O’ with fontanell
 
 The degree of sagittal moulding (i.e. 0 to 3+) is also recorded on the partogram.
 
-![Figure 3C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head and moulding on the partogram](images/3c-4.svg)
-
-Figure 3C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head and moulding on the partogram
-{:.figure-caption}
+> ![Figure 3C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head and moulding on the partogram](images/3c-4.svg)
+> 
+> Figure 3C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head and moulding on the partogram
+{:.figure}
 
 ### K. Recording the duration of contractions
 
@@ -109,10 +109,10 @@ The duration of contractions is also recorded on the partogram. The block is sti
 
 The number of contractions occurring in 10 minutes is recorded by marking off one block for each contraction, e.g. two blocks marked off equals two contractions in 10 minutes, four blocks marked off equals four contractions in 10 minutes, and five blocks if five or more contractions in 10 minutes.
 
-![Figure 3C-5: Recording the duration and frequency of contractions on the partogram](images/3c-5.svg)
-
-Figure 3C-5: Recording the duration and frequency of contractions on the partogram
-{:.figure-caption}
+> ![Figure 3C-5: Recording the duration and frequency of contractions on the partogram](images/3c-5.svg)
+> 
+> Figure 3C-5: Recording the duration and frequency of contractions on the partogram
+{:.figure}
 
 ### M. Recording drugs and intravenous fluid given during labour
 
@@ -134,10 +134,10 @@ After each examination an assessment must be made and recorded on the partogram.
 
 The time, to the nearest half hour, should also be entered on the partogram whenever an observation is recorded, medication is given, an assessment is made or management is altered.
 
-![Figure 3C-6: Documenting medication, assessment, management and time on the partogram](images/3c-6.svg)
-
-Figure 3C-6: Documenting medication, assessment, management and time on the partogram
-{:.figure-caption}
+> ![Figure 3C-6: Documenting medication, assessment, management and time on the partogram](images/3c-6.svg)
+> 
+> Figure 3C-6: Documenting medication, assessment, management and time on the partogram
+{:.figure}
 
 ## Exercises on the correct use of the partogram
 
@@ -173,10 +173,10 @@ The findings must be entered on the latent phase part of the partogram, four hou
 
 The X (cervical dilatation) must be moved horizontally to the right until it lies on the alert line. This will again be at 5 cm dilatation. The O (number of fifths of the head above the pelvic brim) is similarly transferred to lie on the same vertical line opposite the two lines on the vertical axis. The new position of the head (ROA) must be indicated on the O. The length of the cervix is recorded by a 5 mm thick black column on the base line vertically below the X and O. The fact that the membranes have been ruptured is entered in the block provided for medication/ I.V. fluids/management. A ‘C’ in the block provided for liquor indicates that the liquor is clear. The correct method of transferring the above findings from the latent to the active part of the partogram is shown in figure 3C-7. (The length of the cervix and the position of the fetal head may also be entered in the appropriate blocks provided elsewhere on the partogram.)
 
-![Figure 3C-7: Information from case sudy 1 correctly entered onto the partogram](images/3c-7.svg)
-
-Figure 3C-7: Information from case sudy 1 correctly entered onto the partogram
-{:.figure-caption}
+> ![Figure 3C-7: Information from case sudy 1 correctly entered onto the partogram](images/3c-7.svg)
+> 
+> Figure 3C-7: Information from case sudy 1 correctly entered onto the partogram
+{:.figure}
 
 ## Case study 2
 
@@ -216,10 +216,10 @@ At the third complete examination the maternal and fetal conditions are satisfac
 
 Labour is progressing satisfactorily. This is shown by the third X having moved closer to the alert line. Also the head, which has rotated from the left occipito-posterior to the left occipito-anterior position, is engaged. A spontaneous vertex delivery may be expected within an hour.
 
-![Figure 3C-8: Information from case study 2 correctly entered onto the partogram](images/3c-8.svg)
-
-Figure 3C-8: Information from case study 2 correctly entered onto the partogram
-{:.figure-caption}
+> ![Figure 3C-8: Information from case study 2 correctly entered onto the partogram](images/3c-8.svg)
+> 
+> Figure 3C-8: Information from case study 2 correctly entered onto the partogram
+{:.figure}
 
 ## Case study 3
 
@@ -241,7 +241,7 @@ Meconium in the liquor indicates that the fetus is at an increased risk for feta
 
 The most likely outcome is the development of cephalopelvic disproportion. On abdominal examination the head will remain 3/5 or more palpable above the pelvic brim (i.e. unengaged) and on vaginal examination there will be 3+ moulding. An urgent Caesarean section should then be performed.
 
-![Figure 3C-9: Information from case study 3 correctly entered onto the partogram](images/3c-9.svg)
-
-Figure 3C-9: Information from case study 3 correctly entered onto the partogram
-{:.figure-caption}
+> ![Figure 3C-9: Information from case study 3 correctly entered onto the partogram](images/3c-9.svg)
+> 
+> Figure 3C-9: Information from case study 3 correctly entered onto the partogram
+{:.figure}

--- a/intrapartum-care/4a.md
+++ b/intrapartum-care/4a.md
@@ -41,10 +41,10 @@ The midline episiotomy has the danger that it can extend into the rectum to beco
 
 The incision should only be started during a contraction when the presenting part is stretching the perineum. Doing the episiotomy too early may cause severe bleeding and will not immediately assist the delivery. The incision is started in the midline with the scissors pointed 45 degrees away from the anus. It is usually directed to the patient’s left but can also be to the right. Two fingers of the left hand are slipped between the perineum and the presenting part when performing a mediolateral episiotomy.
 
-![Figure 4A-1: The method of performing a left mediolateral episiotomy](images/4a-1.svg)
-
-Figure 4A-1: The method of performing a left mediolateral episiotomy
-{:.figure-caption}
+> ![Figure 4A-1: The method of performing a left mediolateral episiotomy](images/4a-1.svg)
+> 
+> Figure 4A-1: The method of performing a left mediolateral episiotomy
+{:.figure}
 
 ### E. Problems with episiotomies
 
@@ -77,10 +77,10 @@ Arterial bleeders may have to be temporarily clamped, while venous bleeding is e
 1.	Haemostasis must be obtained.
 1.	The needles must be handled with a pair of forceps and not by hand, and should be removed from the operating field as soon as possible.
 
-![Figure 4A-2: The method of safely handling a needle](images/4a-2.svg)
-
-Figure 4A-2: The method of safely handling a needle
-{:.figure-caption}
+> ![Figure 4A-2: The method of safely handling a needle](images/4a-2.svg)
+> 
+> Figure 4A-2: The method of safely handling a needle
+{:.figure}
 
 ### H. The method of suturing an episiotomy
 
@@ -90,26 +90,26 @@ Three layers have to be repaired:
 1.	The muscles.
 1.	The perineal skin.
 
-![Figure 4A-3: An episiotomy wound](images/4a-3.svg)
-
-Figure 4A-3: An episiotomy wound
-{:.figure-caption}
+> ![Figure 4A-3: An episiotomy wound](images/4a-3.svg)
+> 
+> Figure 4A-3: An episiotomy wound
+{:.figure}
 
 There are four important steps in the repair of an episiotomy wound.
 
 *Step 1*: Place a suture (stitch) at the apex (the highest point) of the incision in the vaginal epithelium. Then insert one or two more continuous sutures in the vaginal epithelium. Do not complete suturing the vaginal epithelium when the episiotomy is large or deeply cut but leave this suture and do not cut it. When placing the suture at the apex, be very careful not to prick your finger with the needle.
 
-![Figure 4A-4: Suturing the vaginal epithelium](images/4a-4.svg)
-
-Figure 4A-4: Suturing the vaginal epithelium
-{:.figure-caption}
+> ![Figure 4A-4: Suturing the vaginal epithelium](images/4a-4.svg)
+> 
+> Figure 4A-4: Suturing the vaginal epithelium
+{:.figure}
 
 *Step 2*: Insert interrupted sutures in the muscles. Start at the apex of the wound. The aim is to bring the muscles together firmly and to eliminate any ‘dead space’, i.e. any spaces between the muscles where blood can collect. Remember that the sutures must be inserted at 90 degrees to the line of the wound.
 
-![Figure 4A-5: Suturing the muscles](images/4a-5.svg)
-
-Figure 4A-5: Suturing the muscles
-{:.figure-caption}
+> ![Figure 4A-5: Suturing the muscles](images/4a-5.svg)
+> 
+> Figure 4A-5: Suturing the muscles
+{:.figure}
 
 When suturing the muscles, be careful not to put the suture through the rectum. If you make sure that the point of the needle is seen when crossing from the one side to the other of the deepest part of the wound, the stitch will not be too deep. ‘Figure 8’ stitches (double stitches) are used to suture the muscle layer. When the muscles have been correctly sutured the cut edges of the vaginal epithelium and the skin should be lying close together. The markers for correct alignment are:
 
@@ -118,17 +118,17 @@ When suturing the muscles, be careful not to put the suture through the rectum. 
 
 *Step 3*: Return to the vaginal epithelium and complete the continuous catgut suture, ending at the junction with the skin. Do not pull the sutures tight as they only need to bring the edges of the vaginal epithelium together.
 
-![Figure 4A-6: The correct position of the skin and vaginal epithelium](images/4a-6.svg)
-
-Figure 4A-6: The correct position of the skin and vaginal epithelium
-{:.figure-caption}
+> ![Figure 4A-6: The correct position of the skin and vaginal epithelium](images/4a-6.svg)
+> 
+> Figure 4A-6: The correct position of the skin and vaginal epithelium
+{:.figure}
 
 *Step 4*: Use interrupted sutures with an absorbable suture material to repair the perineal skin. Mattress sutures may be used. Do not pull the sutures tight as they only need to bring the edges of the skin together. Sutures that are too tight become uncomfortable for the patient.
 
-![Figure 4A-7: The repair of the skin](images/4a-7.svg)
-
-Figure 4A-7: The repair of the skin
-{:.figure-caption}
+> ![Figure 4A-7: The repair of the skin](images/4a-7.svg)
+> 
+> Figure 4A-7: The repair of the skin
+{:.figure}
 
 When the suturing is complete:
 

--- a/intrapartum-care/5.md
+++ b/intrapartum-care/5.md
@@ -228,10 +228,10 @@ The management will depend on whether the placenta has been delivered or not.
 
 The management of a patient with a postpartum haemorrhage before the delivery of the placenta is summarised in figure 5-1.
 
-![Figure 5-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta](images/5-1.svg)
-
-Figure 5-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta
-{:.figure-caption}
+> ![Figure 5-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta](images/5-1.svg)
+> 
+> Figure 5-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta
+{:.figure}
 
 ### 5-23 What is the management of a patient with a postpartum haemorrhage, if the placenta has already been delivered?
 
@@ -256,10 +256,10 @@ Note
 
 The management of a patient with a postpartum haemorrhage after the delivery of the placenta is summarised in figure 5-2.
 
-![Figure 5-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta](images/5-2.svg)
-
-Figure 5-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta
-{:.figure-caption}
+> ![Figure 5-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta](images/5-2.svg)
+> 
+> Figure 5-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta
+{:.figure}
 
 ### 5-24 What are the main causes of postpartum haemorrhage?
 

--- a/intrapartum-care/7.md
+++ b/intrapartum-care/7.md
@@ -171,10 +171,10 @@ A patient should only be discharged home after delivery if no abnormalities are 
 1.	The amount, colour and odour of the lochia.
 1.	A postnatal was completed for the mother and infant.
 
-![Figure 7-1: A postnatal card for assessing a woman within the first week and again at 6 weeks after delivery](images/7-1.svg)
-
-Figure 7-1: A postnatal card for assessing a woman within the first week and again at 6 weeks after delivery
-{:.figure-caption}
+> ![Figure 7-1: A postnatal card for assessing a woman within the first week and again at 6 weeks after delivery](images/7-1.svg)
+> 
+> Figure 7-1: A postnatal card for assessing a woman within the first week and again at 6 weeks after delivery
+{:.figure}
 
 ### 7-11 When should a patient be discharged from hospital following a complicated pregnancy and delivery?
 

--- a/maternal-care/1.md
+++ b/maternal-care/1.md
@@ -42,15 +42,15 @@ All information relating to the pregnancy must be entered on a patient-held ante
 
 > The antenatal card is an important source of information during the antenatal period and labour.
 
-![Figure 1-1: The front of an antenatal record card](images/fig-1-1.svg)
+> ![Figure 1-1: The front of an antenatal record card](images/fig-1-1.svg)
+> 
+> Figure 1-1: The front of an antenatal record card
+{:.figure}
 
-Figure 1-1: The front of an antenatal record card
-{:.figure-caption}
-
-![Figure 1-2: The back of an antenatal record card](images/fig-1-2.svg)
-
-Figure 1-2: The back of an antenatal record card
-{:.figure-caption}
+> ![Figure 1-2: The back of an antenatal record card](images/fig-1-2.svg)
+> 
+> Figure 1-2: The back of an antenatal record card
+{:.figure}
 
 ## Diagnosing pregnancy
 
@@ -353,15 +353,15 @@ All risk factors must be entered on the problem list on the back of the antenata
 
 The clinic checklist (Figure 1-3) for the first visit could now be completed. If all the open blocks for the first visit can be ticked off, the visit is completed and all important points have been addressed. The checklist should again be used during further visits to make sure that all problems have been considered (i.e. it should be used as a quality control tool).
 
-![Figure 1-3: The front of a clinic checklist](images/fig-1-3.svg)
+> ![Figure 1-3: The front of a clinic checklist](images/fig-1-3.svg)
+> 
+> Figure 1-3: The front of a clinic checklist
+{:.figure}
 
-Figure 1-3: The front of a clinic checklist
-{:.figure-caption}
-
-![Figure 1-4: The back of a clinic checklist](images/fig-1-4.svg)
-
-Figure 1-4: The back of a clinic checklist
-{:.figure-caption}
+> ![Figure 1-4: The back of a clinic checklist](images/fig-1-4.svg)
+> 
+> Figure 1-4: The back of a clinic checklist
+{:.figure}
 
 ## The second antenatal visit
 

--- a/maternal-care/11.md
+++ b/maternal-care/11.md
@@ -275,10 +275,10 @@ The management will depend on whether the placenta has been delivered or not.
 
 The management of a patient with a postpartum haemorrhage before the delivery of the placenta is summarised in Figure 11-1.
 
-![Figure 11-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta](images/fig-11-1.svg)
-
-Figure 11-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta
-{:.figure-caption}
+> ![Figure 11-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta](images/fig-11-1.svg)
+> 
+> Figure 11-1: The management of a patient with a postpartum haemorrhage before the delivery of the placenta
+{:.figure .large}
 
 ### 11-28 What is the management of a patient with a postpartum haemorrhage, if the placenta has already been delivered?
 
@@ -309,10 +309,10 @@ It is very important that the two causes are differentiated from one another as 
 
 The management of a patient with a post­partum haemorrhage after the delivery of the placenta is summarised in Figure 11-2.
 
-![Figure 11-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta](images/fig-11-2.svg)
-
-Figure 11-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta
-{:.figure-caption}
+> ![Figure 11-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta](images/fig-11-2.svg)
+> 
+> Figure 11-2: The management of a patient with a postpartum haemorrhage after the delivery of the placenta
+{:.figure .large}
 
 ### 11-30 What clinical signs indicate that the bleeding is caused by an atonic uterus?
 

--- a/maternal-care/13.md
+++ b/maternal-care/13.md
@@ -180,10 +180,10 @@ The size and colour of the red cells indicate the probable cause of the anaemia:
 
 The management of a patient with iron-deficiency anaemia during the puerperium is summarised in Figure 13-1.
 
-![Figure 13-1: The management of a patient with iron-deficiency anaemia in pregnancy](images/fig-13-1.svg)
-
-Figure 13-1: The management of a patient with iron-deficiency anaemia in pregnancy
-{:.figure-caption}
+> ![Figure 13-1: The management of a patient with iron-deficiency anaemia in pregnancy](images/fig-13-1.svg)
+> 
+> Figure 13-1: The management of a patient with iron-deficiency anaemia in pregnancy
+{:.figure .large}
 
 ### 13-19 Should all patients receive iron supplements in pregnancy?
 
@@ -355,10 +355,10 @@ The patient must have nothing to eat or drink (except water) from midnight. At 0
 
 The management of patients with an abnormal random blood glucose concentration is summarised in flow diagram 13-2.
 
-![Figure 13-2: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy](images/fig-13-2.svg)
-
-Figure 13-2: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy
-{:.figure-caption}
+> ![Figure 13-2: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy](images/fig-13-2.svg)
+> 
+> Figure 13-2: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy
+{:.figure .large}
 
 ## Case study 1
 

--- a/maternal-care/1a.md
+++ b/maternal-care/1a.md
@@ -46,10 +46,10 @@ It is important to know how many pregnancies the patient has lost. Patients ofte
 
 All these findings should be recorded briefly on the antenatal clinic record.
 
-![Figure 1A-1: Recording past obstetric history](images/fig-1A-1.svg)
-
-Figure 1A-1: Recording past obstetric history
-{:.figure-caption}
+> ![Figure 1A-1: Recording past obstetric history](images/fig-1A-1.svg)
+> 
+> Figure 1A-1: Recording past obstetric history
+{:.figure}
 
 ### C. Medical history
 

--- a/maternal-care/1b.md
+++ b/maternal-care/1b.md
@@ -65,22 +65,22 @@ The following should be specifically looked for and noted:
 	*	If the fundus reaches halfway between the symphysis and the umbilicus, the gestational age is probably 16 weeks.
 	*	If the fundus is at the same height as the umbilicus, the gestational age is probably 22 weeks (1 finger under the umbilicus = 20 weeks and 1 finger above the umbilicus = 24 weeks).
 
-![Figure 1B-1: Determining the uterine size before 24 weeks](images/fig-1B-1.svg)
-
-Figure 1B-1: Determining the uterine size before 24 weeks
-{:.figure-caption}
+> ![Figure 1B-1: Determining the uterine size before 24 weeks](images/fig-1B-1.svg)
+> 
+> Figure 1B-1: Determining the uterine size before 24 weeks
+{:.figure}
 
 ### F. Determining the height of the fundus from 18 weeks gestation
 
-![Figure 1B-2: Determining the fundal height](images/fig-1B-2.svg)
+> ![Figure 1B-2: Determining the fundal height](images/fig-1B-2.svg)
+> 
+> Figure 1B-2: Determining the fundal height
+{:.figure}
 
-Figure 1B-2: Determining the fundal height
-{:.figure-caption}
-
-![Figure 1B-3: Measuring the symphysis-fundus height](images/fig-1B-3.svg)
-
-Figure 1B-3: Measuring the symphysis-fundus height
-{:.figure-caption}
+> ![Figure 1B-3: Measuring the symphysis-fundus height](images/fig-1B-3.svg)
+> 
+> Figure 1B-3: Measuring the symphysis-fundus height
+{:.figure}
 
 The symphysis-fundus height should be measured as follows:
 
@@ -107,20 +107,20 @@ The following must be determined:
 
 There are four specific steps for palpating the fetus. These are performed systematically. With the mother lying comfortably on her back, the examiner faces the patient for the first three steps, and faces towards her feet for the fourth.
 
-![Figure 1B-4: The four steps in palpating the fetus](images/fig-1B-4.svg)
-
-Figure 1B-4: The four steps in palpating the fetus
-{:.figure-caption}
+> ![Figure 1B-4: The four steps in palpating the fetus](images/fig-1B-4.svg)
+> 
+> Figure 1B-4: The four steps in palpating the fetus
+{:.figure}
 
 1.	*First step*. Having established the height of the fundus, the fundus itself is gently palpated with the fingers of both hands, in order to discover which pole of the fetus (breech or head) is present. The head feels hard and round, and is easily movable and ballotable. The breech feels soft, triangular and continuous with the body.
 2.	*Second step*. The hands are now placed on the sides of the abdomen. On one side there is the smooth, firm curve of the back of the fetus, and on the other side, the rather knobbly feel of the fetal limbs. It is often difficult to feel the fetus well when the patient is obese, when there is a lot of liquor, or when the uterus is tight, as in some primigravidas.
 3.	*Third step*. The examiner grasps the lower portion of the abdomen, just above the symphysis pubis, between the thumb and fingers of one hand. The objective is to feel for the presenting part of the fetus and to decide whether the presenting part is loose above the pelvis or fixed in the pelvis. If the head is loose above the pelvis, it can be easily moved and balloted. The head and breech are differentiated in the same way as in the first step.
 4.	*Fourth step*. The objective of this step is to determine the amount of head palpable above the pelvic brim, if there is a cephalic presentation. The examiner faces the patient’s feet, and with the tips of the middle 3 fingers palpates deeply in the pelvic inlet. In this way the head can usually be readily palpated, unless it is already deeply in the pelvis. The amount of the head palpable above the pelvic brim can also be determined.
 
-![Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/fig-1B-5.svg)
-
-Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis
-{:.figure-caption}
+> ![Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/fig-1B-5.svg)
+> 
+> Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis
+{:.figure}
 
 ### I. Special points about the palpation of the fetus
 

--- a/maternal-care/1d.md
+++ b/maternal-care/1d.md
@@ -103,10 +103,10 @@ Note
 1.	*A positive test*: Obvious clumping takes place (flocculation). Definite black particles form which are clearly seen with the naked eye. While the particles cover the whole area of the spread-out droplet, they tend to gather around the edge of the droplet.
 2.	*A negative test*: *No* clumping takes place. The small black particles of the carbon antigen tend to collect at the centre of the spread-out droplet where they form a black dot. They do not collect around the rim of the droplet as is seen in a positive test.
 
-![Figure 1D-1: Examples of positive and negative tests](images/fig-1D-1.svg)
-
-Figure 1D-1: Examples of positive and negative tests
-{:.figure-caption}
+> ![Figure 1D-1: Examples of positive and negative tests](images/fig-1D-1.svg)
+> 
+> Figure 1D-1: Examples of positive and negative tests
+{:.figure}
 
 ### K. Interpretation of the results of the RPR card test
 

--- a/maternal-care/1f.md
+++ b/maternal-care/1f.md
@@ -56,42 +56,42 @@ The examination consists of both looking (inspection) and feeling (palpating). W
 
 Ask the woman to sit down on the examining couch facing you with her arms relaxed at her sides. Look at her breasts asymmetry, nipple inversion, skin changes and redness. You may even be able to see a breast lump.
 
-![Figure 1F-1: Position during inspection of breasts.](images/fig-1F-1.svg)
-
-Figure 1F-1: Position during inspection of breasts.
-{:.figure-caption}
+> ![Figure 1F-1: Position during inspection of breasts.](images/fig-1F-1.svg)
+> 
+> Figure 1F-1: Position during inspection of breasts.
+{:.figure}
 
 Next ask her to raise both her arms above her head. Look for any skin puckering (skin pulled in). This will help identify a lump that is attached to the skin.
 
-![Figure 1F-2: Position with arms raised while looking for a lump or skin puckering.](images/fig-1F-2.svg)
-
-Figure 1F-2: Position with arms raised while looking for a lump or skin puckering.
-{:.figure-caption}
+> ![Figure 1F-2: Position with arms raised while looking for a lump or skin puckering.](images/fig-1F-2.svg)
+> 
+> Figure 1F-2: Position with arms raised while looking for a lump or skin puckering.
+{:.figure}
 
 Finally ask the woman to put her hands on her hips and squeeze (push her hands towards each other). This will tighten her chest muscles. Look and see if an area of skin is puckering due to being attached (tethered) to underlying muscle. This may indicate the site of a breast lump.
 
-![Figure 1F-3: Position with hands on hips while looking for tethering to underlying muscle](images/fig-1F-3.svg)
-
-Figure 1F-3: Position with hands on hips while looking for tethering to underlying muscle
-{:.figure-caption}
+> ![Figure 1F-3: Position with hands on hips while looking for tethering to underlying muscle](images/fig-1F-3.svg)
+> 
+> Figure 1F-3: Position with hands on hips while looking for tethering to underlying muscle
+{:.figure}
 
 ### H. Palpation for enlarged supraclavicular lymph nodes
 
 While the woman is still sitting it is a good opportunity to palpate for enlarged lymph nodes. Start by palpating above her clavicles (collar bones) for an enlarged supraclavicular lymph node. Breast cancers towards the centre of the chest may spread to this site.
 
-![Figure 1F-4: Position for supraclavicular node examination.](images/fig-1F-4.svg)
-
-Figure 1F-4: Position for supraclavicular node examination.
-{:.figure-caption}
+> ![Figure 1F-4: Position for supraclavicular node examination.](images/fig-1F-4.svg)
+> 
+> Figure 1F-4: Position for supraclavicular node examination.
+{:.figure}
 
 ### I. Palpation for enlarged axillary lymph nodes
 
 To examine the (axillae) armpits properly the woman must be relaxed. If she is very ticklish it helps to press more firmly. The best way to get a woman to relax her muscles is by asking her to extend her arms and rest them on your shoulders while you examine the armpits.
 
-![Figure 1F-5: Position while feeling in the armpits for nodes.](images/fig-1F-5.svg)
-
-Figure 1F-5: Position while feeling in the armpits for nodes.
-{:.figure-caption}
+> ![Figure 1F-5: Position while feeling in the armpits for nodes.](images/fig-1F-5.svg)
+> 
+> Figure 1F-5: Position while feeling in the armpits for nodes.
+{:.figure}
 
 Feel in the two armpits at the same time for any lumps. This allows you to compare the two armpits which are shaped like pyramids. You should feel along the inside wall and towards the front (anterior) for lymph nodes. Remember to feel at the top of the armpit also. If you think you feel a lump, examine that armpit very carefully.
 
@@ -99,19 +99,19 @@ Feel in the two armpits at the same time for any lumps. This allows you to compa
 
 Finally lie the woman down flat on her back and examine one breast at a time. Ask her to raise that arm above her head on the bed. This will flatten the breast and make examination easier. It helps to think of the breasts being divided into strips and then examine each strip of breast from the centre of the chest outwards. The breast extends from the clavicle above to the 6th rib below and also towards the axilla. The whole area of the breast must be carefully examined. Always use the tips of your fingers (the most sensitive part of your hand) with the rest of your hand gently resting against the breast. Do not use cold hands.
 
-![Figure 1F-6: The breast is palpated in strips to make sure the whole breast is examined.](images/fig-1F-6.svg)
-
-Figure 1F-6: The breast is palpated in strips to make sure the whole breast is examined.
-{:.figure-caption}
+> ![Figure 1F-6: The breast is palpated in strips to make sure the whole breast is examined.](images/fig-1F-6.svg)
+> 
+> Figure 1F-6: The breast is palpated in strips to make sure the whole breast is examined.
+{:.figure}
 
 ### J. Palpate behind the nipples
 
 Never forget to examine behind the nipples and surrounding areolae for any abnormalities such as skin changes, lumps or an inverted nipple. It is best to leave the nipple examination to the end once you have won the woman’s trust.
 
-![Figure 1F-7: The breast being examined using finger tips with a flat hand.](images/fig-1F-7.svg)
-
-Figure 1F-7: The breast being examined using finger tips with a flat hand.
-{:.figure-caption}
+> ![Figure 1F-7: The breast being examined using finger tips with a flat hand.](images/fig-1F-7.svg)
+> 
+> Figure 1F-7: The breast being examined using finger tips with a flat hand.
+{:.figure}
 
 Examining a woman’s breasts provides an excellent opportunity to teach her how to examine her own breasts each month after the end of her period when her breasts are softer. This is something all women should learn and practice regularly as it increases the chance of detecting an early breast cancer which can be cured.
 

--- a/maternal-care/2.md
+++ b/maternal-care/2.md
@@ -104,10 +104,10 @@ The symphysis-fundus growth curve compares the SF height to the duration of preg
 
 Between 18 and 36 weeks of pregnancy, the SF height normally increases by about 1 cm a week.
 
-![Figure 2-1: The symphysis-fundus growth chart](images/fig-2-1.svg)
-
-Figure 2-1: The symphysis-fundus growth chart
-{:.figure-caption}
+> ![Figure 2-1: The symphysis-fundus growth chart](images/fig-2-1.svg)
+> 
+> Figure 2-1: The symphysis-fundus growth chart
+{:.figure}
 
 ### 2-9 When will the symphysis-fundus height suggest intra-uterine growth restriction?
 
@@ -119,20 +119,20 @@ If any of the following are found:
 
 Note that a measurement that was originally normal, but on subsequent examinations has fallen to below the 10th centile, indicates intra-uterine growth restriction and not incorrect dates.
 
-![Figure 2-2: One measurement below the 10th centile](images/fig-2-2.svg)
+> ![Figure 2-2: One measurement below the 10th centile](images/fig-2-2.svg)
+> 
+> Figure 2-2: One measurement below the 10th centile
+{:.figure}
 
-Figure 2-2: One measurement below the 10th centile
-{:.figure-caption}
+> ![Figure 2-3: Three successive measurements that remain the same](images/fig-2-3.svg)
+> 
+> Figure 2-3: Three successive measurements that remain the same
+{:.figure}
 
-![Figure 2-3: Three successive measurements that remain the same](images/fig-2-3.svg)
-
-Figure 2-3: Three successive measurements that remain the same
-{:.figure-caption}
-
-![Figure 2-4: A measurement less than that recorded two visits before](images/fig-2-4.svg)
-
-Figure 2-4: A measurement less than that recorded two visits before
-{:.figure-caption}
+> ![Figure 2-4: A measurement less than that recorded two visits before](images/fig-2-4.svg)
+> 
+> Figure 2-4: A measurement less than that recorded two visits before
+{:.figure}
 
 ### 2-10 How can you identify severe intra-uterine growth restriction?
 
@@ -232,10 +232,10 @@ Tests with electronic equipment have shown that mothers can detect fetal movemen
 Note
 :	A patient who lives far away from her nearest hospital or clinic should continue with bed rest, but if the movements are 3 or fewer over a 6-hour period, then arrangements must be made for her to be moved to the nearest hospital.
 
-![Figure 2-5: The management of a patient with decreased fetal movements](images/fig-2-5.svg)
-
-Figure 2-5: The management of a patient with decreased fetal movements
-{:.figure-caption}
+> ![Figure 2-5: The management of a patient with decreased fetal movements](images/fig-2-5.svg)
+> 
+> Figure 2-5: The management of a patient with decreased fetal movements
+{:.figure}
 
 ### 2-26 What should you do if a patient with reduced fetal movements arrives at a clinic or hospital without a cardiotocograph (CTG machine)?
 
@@ -246,10 +246,10 @@ The patient should be given a drink containing sugar (e.g. tea) to exclude hypog
 
 The management of a patient with confirmed decreased fetal movements in a hospital is demonstrated in Figure 2-6.
 
-![Figure 2-6: The management of a patient with confirmed decreased fetal movements in a hospital](images/fig-2-6.svg)
-
-Figure 2-6: The management of a patient with confirmed decreased fetal movements in a hospital
-{:.figure-caption}
+> ![Figure 2-6: The management of a patient with confirmed decreased fetal movements in a hospital](images/fig-2-6.svg)
+> 
+> Figure 2-6: The management of a patient with confirmed decreased fetal movements in a hospital
+{:.figure}
 
 ### 2-27 What should the doctor do, in a hospital without fetal heart rate monitoring equipment, if there are decreased fetal movements?
 
@@ -301,10 +301,10 @@ Hospitals which deal with mainly low-risk patients can manage perfectly well wit
 1.	The fetal heart rate pattern is said to be reactive when it has at least 2 accelerations per 10 minutes, each with an amplitude (increase in the number of beats) of 15 or more beats per minute and a duration of at least 15 seconds (Figure 2-5).
 2.	In a non-reactive fetal heart rate pattern there are no accelerations.
 
-![Figure 2-7: Reactive and non-reactive fetal heart rate patterns](images/fig-2-7.svg)
-
-Figure 2-7: Reactive and non-reactive fetal heart rate patterns
-{:.figure-caption}
+> ![Figure 2-7: Reactive and non-reactive fetal heart rate patterns](images/fig-2-7.svg)
+> 
+> Figure 2-7: Reactive and non-reactive fetal heart rate patterns
+{:.figure}
 
 ### 2-32 How is the variability in the fetal heart rate used to determine whether a fetal heart rate pattern is non-reactive?
 
@@ -316,10 +316,10 @@ Figure 2-7: Reactive and non-reactive fetal heart rate patterns
 	*	The fetal heart monitoring must be repeated after 45 minutes.
 	*	If the poor variability persists, there is fetal distress.
 
-![Figure 2-8: Non-reactive fetal heart rate pattern with good and poor variability.](images/fig-2-8.svg)
-
-Figure 2-8: Non-reactive fetal heart rate pattern with good and poor variability.
-{:.figure-caption}
+> ![Figure 2-8: Non-reactive fetal heart rate pattern with good and poor variability.](images/fig-2-8.svg)
+> 
+> Figure 2-8: Non-reactive fetal heart rate pattern with good and poor variability.
+{:.figure}
 	
 ### 2-33 Why must you repeat the cardiotocogram after 45 minutes in a patient with a non-reactive fetal heart rate pattern and poor variability?
 
@@ -336,19 +336,19 @@ If contractions are present during fetal heart rate monitoring in the antenatal 
 1.	A normal stress test has no fetal heart rate decelerations during or following at least 2 contractions which last at least 30 seconds (Figure 2-7).
 2.	An abnormal stress test has late decelerations associated with uterine contractions (Figure 2-7). This indicates that the fetus is distressed.
 
-![Figure 2-9: Normal and abnormal stress tests](images/fig-2-9.svg)
-
-Figure 2-9: Normal and abnormal stress tests
-{:.figure-caption}
+> ![Figure 2-9: Normal and abnormal stress tests](images/fig-2-9.svg)
+> 
+> Figure 2-9: Normal and abnormal stress tests
+{:.figure}
 
 ### 2-36 What are the characteristics of a late deceleration?
 
 On the cardiotocogram the trough of the deceleration occurs 30 seconds or later after the peak of the contraction (Figure 2-8).
 
-![Figure 2-10: A late deceleration](images/fig-2-10.svg)
-
-Figure 2-10: A late deceleration
-{:.figure-caption}
+> ![Figure 2-10: A late deceleration](images/fig-2-10.svg)
+> 
+> Figure 2-10: A late deceleration
+{:.figure}
 
 ### 2-37 What should you do in the case of an abnormal stress test, fetal bradycardia, repeated decelerations, or a non-reactive fetal heart rate pattern with persistent poor variability?
 
@@ -359,15 +359,15 @@ Figure 2-10: A late deceleration
 
 The use of antenatal fetal heart rate monitoring is demonstrated in Figure 2-11.
 
-![Figure 2-11: The use of antenatal fetal heart rate monitoring](images/fig-2-11.svg)
+> ![Figure 2-11: The use of antenatal fetal heart rate monitoring](images/fig-2-11.svg)
+> 
+> Figure 2-11: The use of antenatal fetal heart rate monitoring
+{:.figure}
 
-Figure 2-11: The use of antenatal fetal heart rate monitoring
-{:.figure-caption}
-
-![Figure 2-12: The interpretation of variability when the fetal heart rate pattern is nonreactive with no spontaneous uterine contractions](images/fig-2-12.svg)
-
-Figure 2-12: The interpretation of variability when the fetal heart rate pattern is nonreactive with no spontaneous uterine contractions
-{:.figure-caption}
+> ![Figure 2-12: The interpretation of variability when the fetal heart rate pattern is nonreactive with no spontaneous uterine contractions](images/fig-2-12.svg)
+> 
+> Figure 2-12: The interpretation of variability when the fetal heart rate pattern is nonreactive with no spontaneous uterine contractions
+{:.figure}
 
 ### 2-38 Why should you not immediately do a Caesarean section if the fetal heart rate pattern indicates fetal distress and the fetus is viable?
 

--- a/maternal-care/2a.md
+++ b/maternal-care/2a.md
@@ -36,10 +36,10 @@ The following items should be recorded on the back of the antenatal card every t
 
 The symphysis-fundus (SF) height is recorded on the antenatal graph while the other information is recorded in the spaces provided (see Figure 2A-1).
 
-![Figure 2A-1: The back of the antenatal card](images/fig-2A-1.svg)
-
-Figure 2A-1: The back of the antenatal card
-{:.figure-caption}
+> ![Figure 2A-1: The back of the antenatal card](images/fig-2A-1.svg)
+> 
+> Figure 2A-1: The back of the antenatal card
+{:.figure}
 
 ### B. Recording the results of the rapid HIV test on the antenatal card.
 
@@ -47,20 +47,20 @@ Figure 2A-1: The back of the antenatal card
 2.	If both the first rapid test and the confirmatory (second) test are positive, it is accepted that the patient is HIV positive. Circle ‘Yes’ for the test being done and again ‘Yes’ for the test being positive for RVD. The test was therefore accepted and precautions are needed (see Figure 2A-3). The patient must receive appropriate antiretrovirals to prevent mother-to-child transmission of HIV.
 3.	If, after counselling, the patient decides not to have an HIV test, ‘No’ must be circled as the test was not done. As the test was not done, a decision about precautions is not required (see Figure 2A-4).
 
-![Figure 2A-2: Recording of a negative HIV test on the antenatal card](images/fig-2A-2.svg)
+> ![Figure 2A-2: Recording of a negative HIV test on the antenatal card](images/fig-2A-2.svg)
+> 
+> Figure 2A-2: Recording of a negative HIV test on the antenatal card
+{:.figure}
 
-Figure 2A-2: Recording of a negative HIV test on the antenatal card
-{:.figure-caption}
+> ![Figure 2A-3: Recording of a positive HIV test on the antenatal card](images/fig-2A-3.svg)
+> 
+> Figure 2A-3: Recording of a positive HIV test on the antenatal card
+{:.figure}
 
-![Figure 2A-3: Recording of a positive HIV test on the antenatal card](images/fig-2A-3.svg)
-
-Figure 2A-3: Recording of a positive HIV test on the antenatal card
-{:.figure-caption}
-
-![Figure 2A-4: Recording that the patient decided not to be tested for HIV](images/fig-2A-4.svg)
-
-Figure 2A-4: Recording that the patient decided not to be tested for HIV
-{:.figure-caption}
+> ![Figure 2A-4: Recording that the patient decided not to be tested for HIV](images/fig-2A-4.svg)
+> 
+> Figure 2A-4: Recording that the patient decided not to be tested for HIV
+{:.figure}
 
 ### C. The significance of the lines on the graph
 
@@ -77,10 +77,10 @@ The three lines represent the normal increase in the symphysis-fundus or SF heig
 5.	The method whereby the gestational age was determined must now be ticked in the appropriate block at the top left-hand corner of the chart. In this case ‘Dates’ should be ticked.
 6.	Between 18 and 36 weeks the SF height in centimetres should be plotted on the SF curve to determine the gestational age in weeks. If the fundal height is at the level of the umbilicus or higher, and the SF height differs from the gestational age by 4 weeks or more, the SF height should be plotted.
 
-![Figure 2A-5: An s-f height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th](images/fig-2A-5.svg)
-
-Figure 2A-5: An s-f height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th
-{:.figure-caption}
+> ![Figure 2A-5: An s-f height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th](images/fig-2A-5.svg)
+> 
+> Figure 2A-5: An s-f height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th
+{:.figure}
 
 ### E. Plotting the SF height for the first time when the patient does not know the date of her last menstrual period
 
@@ -89,10 +89,10 @@ Figure 2A-5: An s-f height measurement of 21 cm at a gestational age of 24 weeks
 3.	The method whereby the gestational age was determined must now be ticked in the appropriate block at the top left-hand corner of the chart. In this case ‘SF-measurement’ should be ticked.
 4.	The fundal growth must be carefully recorded at the following visits. If little or no growth occurs in the next 4 weeks, the diagnosis of intra-uterine growth restriction must be made. If excessive growth occurs, multiple pregnancy must be excluded. Normal growth with the SF height between the 90th and 10th centiles confirms a normal growing singleton pregnancy.
 
-![Figure2A-6: Recording the s-f height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4 October.](images/fig-2A-6.svg)
-
-Figure2A-6: Recording the s-f height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4 October.
-{:.figure-caption}
+> ![Figure 2A-6: Recording the s-f height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4 October.](images/fig-2A-6.svg)
+> 
+> Figure 2A-6: Recording the s-f height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4 October.
+{:.figure}
 
 ### F. The first recording of the SF height when the duration of pregnancy, as determined by her last normal menstrual period, differs from that determined by the SF height by four or more weeks.
 
@@ -101,19 +101,19 @@ Figure2A-6: Recording the s-f height of 27 cm on the 50th centile when a patient
 3.	The method by which the gestational age is estimated must be recorded in the box at the top left-hand corner of the growth chart. In this case a tick should be made opposite ‘SF measurement’.
 4.	The fundal growth must be carefully recorded at the following visits. If little or no growth occurs in the next 4 weeks, a diagnosis of intra-uterine growth restriction must be made. If excessive growth occurs, multiple pregnancy must be excluded. Normal growth with the SF height between the 90th and 10th centiles confirms a normal growing singleton pregnancy. This information also confirms that using the SF height to determine gestational age was correct.
 
-![Figure 2A-7: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the s-f height measurement is 25 cm.](images/fig-2A-7.svg)
-
-Figure 2A-7: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the s-f height measurement is 25 cm.
-{:.figure-caption}
+> ![Figure 2A-7: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the s-f height measurement is 25 cm.](images/fig-2A-7.svg)
+> 
+> Figure 2A-7: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the s-f height measurement is 25 cm.
+{:.figure}
 
 ### G. Plotting the symphysis-fundus height at subsequent antenatal visits
 
 The symphysis-fundus height must be plotted on the graph at every subsequent antenatal clinic visit. As before, the symphysis-fundus height measurement and the gestational age are used to determine where the dot should be made on the graph. For example, if the patient’s present visit is 4 weeks after she last attended the antenatal clinic, the SF height measurement must be plotted 4 weeks later on the graph (Figure 2A-8).
 
-![Figure 2A-8: A patient’s SF height measurement is 25 cm at 26 weeks and then 31 cm at 30 weeks. Four weeks after her last visit the SF height is 32 cm.](images/fig-2A-8.svg)
-
-Figure 2A-8: A patient’s SF height measurement is 25 cm at 26 weeks and then 31 cm at 30 weeks. Four weeks after her last visit the SF height is 32 cm.
-{:.figure-caption}
+> ![Figure 2A-8: A patient’s SF height measurement is 25 cm at 26 weeks and then 31 cm at 30 weeks. Four weeks after her last visit the SF height is 32 cm.](images/fig-2A-8.svg)
+> 
+> Figure 2A-8: A patient’s SF height measurement is 25 cm at 26 weeks and then 31 cm at 30 weeks. Four weeks after her last visit the SF height is 32 cm.
+{:.figure}
 
 ### H. Recording the presenting part and the amount of fetal head palpable above the brim of the pelvis
 
@@ -123,7 +123,7 @@ From 34 weeks gestation onwards the lie and the presenting part must be determin
 
 A space for brief notes is provided on the antenatal card. A block is also provided for a problem list. Few notes are needed and usually there are no notes for patients that are assessed as being low risk with normal pregnancies (Figure 2A-9).
 
-![Figure 2A-9: A problem list with short notes](images/fig-2A-9.svg)
-
-Figure 2A-9: A problem list with short notes
-{:.figure-caption}
+> ![Figure 2A-9: A problem list with short notes](images/fig-2A-9.svg)
+> 
+> Figure 2A-9: A problem list with short notes
+{:.figure}

--- a/maternal-care/4.md
+++ b/maternal-care/4.md
@@ -65,10 +65,10 @@ The management must always be provided in the following order:
 
 The initial management and diagnosis of a patient with vaginal bleeding is summarised in Figure 4-1.
 
-![Figure 4-1: Initial management of a patient with vaginal bleeding](images/fig-4-1.svg)
-
-Figure 4-1: Initial management of a patient with vaginal bleeding
-{:.figure-caption}
+> ![Figure 4-1: Initial management of a patient with vaginal bleeding](images/fig-4-1.svg)
+> 
+> Figure 4-1: Initial management of a patient with vaginal bleeding
+{:.figure}
 
 ### 4-5 What symptoms and signs indicate that the patient is shocked due to blood loss?
 
@@ -178,10 +178,10 @@ The management of abruptio placentae is summarised in Figure 4-2.
 
 > The diagnosis of severe abruptio placentae can usually be made from the history and physical examination.
 
-![Figure 4-2: Management of a patient with an abruptio placentae](images/fig-4-2.svg)
-
-Figure 4-2: Management of a patient with an abruptio placentae
-{:.figure-caption}
+> ![Figure 4-2: Management of a patient with an abruptio placentae](images/fig-4-2.svg)
+> 
+> Figure 4-2: Management of a patient with an abruptio placentae
+{:.figure}
 
 ### 4-17 What would you do if the fetal heartbeat was still present?
 
@@ -298,15 +298,15 @@ In most cases, the position of the placenta moves away from the internal os of t
 
 The management of a patient with a placenta praevia is summarised in Figures 4-3 and 4-4.
 
-![Figure 4-3: Management of a patient with a placenta praevia before 36 weeks](images/fig-4-3.svg)
+> ![Figure 4-3: Management of a patient with a placenta praevia before 36 weeks](images/fig-4-3.svg)
+> 
+> Figure 4-3: Management of a patient with a placenta praevia before 36 weeks
+{:.figure}
 
-Figure 4-3: Management of a patient with a placenta praevia before 36 weeks
-{:.figure-caption}
-
-![Figure 4-4: Management of a patient with a placenta praevia at 36 weeks or more](images/fig-4-4.svg)
-
-Figure 4-4: Management of a patient with a placenta praevia at 36 weeks or more
-{:.figure-caption}
+> ![Figure 4-4: Management of a patient with a placenta praevia at 36 weeks or more](images/fig-4-4.svg)
+> 
+> Figure 4-4: Management of a patient with a placenta praevia at 36 weeks or more
+{:.figure}
 
 ### 4-33 When a patient with placenta praevia is less than 38 weeks pregnant and is being managed conservatively, what amount of bleeding would indicate that you should deliver the fetus?
 

--- a/maternal-care/5.md
+++ b/maternal-care/5.md
@@ -243,10 +243,10 @@ Note
 
 The management of a patient with preterm labour is summarised in Figure 5-1.
 
-![Figure 5-1: The management of a patient with preterm labour when the duration of pregnancy is less than 34 weeks](images/fig-5-1.svg)
-
-Figure 5-1: The management of a patient with preterm labour when the duration of pregnancy is less than 34 weeks
-{:.figure-caption}
+> ![Figure 5-1: The management of a patient with preterm labour when the duration of pregnancy is less than 34 weeks](images/fig-5-1.svg)
+> 
+> Figure 5-1: The management of a patient with preterm labour when the duration of pregnancy is less than 34 weeks
+{:.figure}
 
 ### 5-23 What are the contraindications to the suppression of preterm labour?
 
@@ -352,10 +352,10 @@ There are two possible ways of managing preterm rupture of the membranes:
 
 The management of a patient with preterm rupture of the membranes is summarised in Figure 5-2.
 
-![Figure 5-2: The management of a patient with preterm prelabour rupture of the membranes](images/fig-5-2.svg)
-
-Figure 5-2: The management of a patient with preterm prelabour rupture of the membranes
-{:.figure-caption}
+> ![Figure 5-2: The management of a patient with preterm prelabour rupture of the membranes](images/fig-5-2.svg)
+> 
+> Figure 5-2: The management of a patient with preterm prelabour rupture of the membranes
+{:.figure}
 
 ### 5-35 How should you decide which method of management to use?
 

--- a/maternal-care/6.md
+++ b/maternal-care/6.md
@@ -157,10 +157,10 @@ The normal range of oral temperature is 36.0 to 37.0 °C. Therefore, a temperatu
 
 The temperature is recorded in the appropriate space on the partogram as shown in figure 6-1.
 
-![Figure 6-1: Recording maternal observations on the partogram](images/fig-6-1.svg)
-
-Figure 6-1: Recording maternal observations on the partogram
-{:.figure-caption}
+> ![Figure 6-1: Recording maternal observations on the partogram](images/fig-6-1.svg)
+> 
+> Figure 6-1: Recording maternal observations on the partogram
+{:.figure}
 
 ### 6-23 What are the causes of pyrexia during labour?
 

--- a/maternal-care/7.md
+++ b/maternal-care/7.md
@@ -152,10 +152,10 @@ Note
 
 Early decelerations are characterised by a slowing of the fetal heart rate starting at the beginning of the contraction, and returning to normal by the end of the contraction. Early decelerations are usually due to compression of the fetal head with a resultant increase in vagal stimulation, which causes the heart rate to slow during the contraction.
 
-![Figure 7-1: An early deceleration](images/fig-7-1.svg)
-
-Figure 7-1: An early deceleration
-{:.figure-caption}
+> ![Figure 7-1: An early deceleration](images/fig-7-1.svg)
+> 
+> Figure 7-1: An early deceleration
+{:.figure}
 
 ### 7-17 What is the significance of early decelerations?
 
@@ -173,10 +173,10 @@ A late deceleration is a slowing of the fetal heart rate during a contraction, w
 Note
 :	When using a cardiotocograph, a late deceleration is diagnosed when the lowest point of the deceleration occurs 30 seconds or more after the peak of the contraction.
 
-![Figure 7-2: A late deceleration](images/fig-7-2.svg)
-
-Figure 7-2: A late deceleration
-{:.figure-caption}
+> ![Figure 7-2: A late deceleration](images/fig-7-2.svg)
+> 
+> Figure 7-2: A late deceleration
+{:.figure}
 
 ### 7-19 What is the significance of late decelerations?
 
@@ -193,10 +193,10 @@ Variable decelerations are not easy to recognise with a fetal stethoscope or dop
 Note
 :	Variable decelerations accompanied by loss of variability may indicate fetal distress. Variable decelerations with good variability is reassuring.
 
-![Figure 7-3: Variable decelerations](images/fig-7-3.svg)
-
-Figure 7-3: Variable decelerations
-{:.figure-caption}
+> ![Figure 7-3: Variable decelerations](images/fig-7-3.svg)
+> 
+> Figure 7-3: Variable decelerations
+{:.figure}
 
 ### 7-21 What is a baseline tachycardia?
 
@@ -338,10 +338,10 @@ The liquor findings should be recorded when:
 2.	A vaginal examination is done.
 3.	A change in the liquor findings is noticed, e.g. if the liquor becomes meconium stained.
 
-![Figure 7-4: Recording fetal observations on the partogram](images/fig-7-4.svg)
-
-Figure 7-4: Recording fetal observations on the partogram
-{:.figure-caption}
+> ![Figure 7-4: Recording fetal observations on the partogram](images/fig-7-4.svg)
+> 
+> Figure 7-4: Recording fetal observations on the partogram
+{:.figure}
 
 ## Case study 1
 

--- a/maternal-care/8.md
+++ b/maternal-care/8.md
@@ -87,10 +87,10 @@ A partogram is a chart on which the progress of labour over time can be presente
 
 An example of a partogram is shown in figure 8-1.
 
-![Figure 8-1: An example of a partogram](images/fig-8-1.svg)
-
-Figure 8-1: An example of a partogram
-{:.figure-caption}
+> ![Figure 8-1: An example of a partogram](images/fig-8-1.svg)
+> 
+> Figure 8-1: An example of a partogram
+{:.figure}
 
 ### 8-8 What is the first oblique line on the partogram called?
 

--- a/maternal-care/8a.md
+++ b/maternal-care/8a.md
@@ -73,10 +73,10 @@ It is also important to know the presentation of the fetus. If a breech presenta
 
 If the presentation is cephalic, it is sometimes possible when palpating the abdomen to determine the presenting part of the fetal head (vertex, face or brow). Figure 8A-1 indicates some features that can assist you in determining the presentation.
 
-![Figure 8A-1: Vertex, face and brow presentations](images/fig-8A-1.svg)
-
-Figure 8A-1: Vertex, face and brow presentations
-{:.figure-caption}
+> ![Figure 8A-1: Vertex, face and brow presentations](images/fig-8A-1.svg)
+> 
+> Figure 8A-1: Vertex, face and brow presentations
+{:.figure}
 
 ### H. Descent and engagement of the head
 
@@ -94,10 +94,10 @@ It is very important to be able to distinguish between 3/5 and 2/5 head palpable
 
 > Descent and engagement of the head are assessed on abdominal and not on vaginal examination.
 
-![Figure 8A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/fig-8A-2.svg)
-
-Figure 8A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis
-{:.figure-caption}
+> ![Figure 8A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/fig-8A-2.svg)
+> 
+> Figure 8A-2: An accurate method of determining the amount of head palpable above the brim of the pelvis
+{:.figure}
 
 ### I. Hardness and tenderness of the uterus
 
@@ -133,10 +133,10 @@ Contractions can be felt by placing a hand on the abdomen and feeling when the u
 2.	Contractions lasting 20–40 seconds (‘moderate contractions’)
 3.	Contractions lasting more than 40 seconds (‘strong contractions’).
 
-![Figure 8A-3: Method of grading the duration of uterine contractions for recording on the partogram](images/fig-8A-3.svg)
-
-Figure 8A-3: Method of grading the duration of uterine contractions for recording on the partogram
-{:.figure-caption}
+> ![Figure 8A-3: Method of grading the duration of uterine contractions for recording on the partogram](images/fig-8A-3.svg)
+> 
+> Figure 8A-3: Method of grading the duration of uterine contractions for recording on the partogram
+{:.figure}
 
 ### L. Grading the frequency and duration of contractions
 

--- a/maternal-care/8b.md
+++ b/maternal-care/8b.md
@@ -92,10 +92,10 @@ Dilatation must be assessed in centimetres, and is best measured by comparing th
 1.	If the cervix is very thin, it may be difficult to feel, and the patient may be said to be fully dilated, when in fact she is not.
 2.	When feeling the rim of the cervix, it is easy to stretch it, or pass the fingers through the cervix and feel the rim with the side of the fingers. Both of these methods cause the recording of dilatation to be more than it really is. The correct method is to place the tips of the fingers on the edges of the cervix.
 
-![Figure 8B-1: The correct method of measuring cervical dilatation](images/fig-8B-1.svg)
-
-Figure 8B-1: The correct method of measuring cervical dilatation
-{:.figure-caption}
+> ![Figure 8B-1: The correct method of measuring cervical dilatation](images/fig-8B-1.svg)
+> 
+> Figure 8B-1: The correct method of measuring cervical dilatation
+{:.figure}
 
 ## The membranes and liquor
 
@@ -142,25 +142,25 @@ The presenting part is usually the head but may be the breech, the arm, or the s
 	*	The anus and the ischial tuberosities form a straight line.
 5.	*Features of a shoulder presentation*. On abdominal examination the lie will be transverse or oblique. Features of a shoulder presentation on vaginal examination will be quite easy if the arm has prolapsed. The shoulder is not always that easy to identify, unless the arm can be felt. The presenting part is usually high.
 
-![Figure 8B-2: Features of an occiput presentation](images/fig-8B-2.svg)
+> ![Figure 8B-2: Features of an occiput presentation](images/fig-8B-2.svg)
+> 
+> Figure 8B-2: Features of an occiput presentation
+{:.figure}
 
-Figure 8B-2: Features of an occiput presentation
-{:.figure-caption}
+> ![Figure 8B-3: Features of a face presentation](images/fig-8B-3.svg)
+> 
+> Figure 8B-3: Features of a face presentation
+{:.figure}
 
-![Figure 8B-3: Features of a face presentation](images/fig-8B-3.svg)
+> ![Figure 8B-4: Features of a brow presentation](images/fig-8B-4.svg)
+> 
+> Figure 8B-4: Features of a brow presentation
+{:.figure}
 
-Figure 8B-3: Features of a face presentation
-{:.figure-caption}
-
-![Figure 8B-4: Features of a brow presentation](images/fig-8B-4.svg)
-
-Figure 8B-4: Features of a brow presentation
-{:.figure-caption}
-
-![Figure 8B-5: Features of a breech presentation](images/fig-8B-5.svg)
-
-Figure 8B-5: Features of a breech presentation
-{:.figure-caption}
+> ![Figure 8B-5: Features of a breech presentation](images/fig-8B-5.svg)
+> 
+> Figure 8B-5: Features of a breech presentation
+{:.figure}
 
 ### I. Determining the position of the presenting part
 
@@ -170,10 +170,10 @@ Position means the relationship of a fixed point on the presenting part (i.e. th
 2.	In a face presentation the point of reference is the chin (i.e. the mentum).
 3.	In a breech presentation the point of reference is the sacrum of the fetus.
 
-![Figure 8B-6: Examples of the position of the presenting part with the patient lying on her back](images/fig-8B-6.svg)
-
-Figure 8B-6: Examples of the position of the presenting part with the patient lying on her back
-{:.figure-caption}
+> ![Figure 8B-6: Examples of the position of the presenting part with the patient lying on her back](images/fig-8B-6.svg)
+> 
+> Figure 8B-6: Examples of the position of the presenting part with the patient lying on her back
+{:.figure}
 
 ### J. Determining the descent and engagement of the head
 
@@ -213,20 +213,20 @@ When assessing the pelvis, the size and shape of the pelvic inlet, the mid-pelvi
 
 It is important to use a step-by-step method to assess the pelvis.
 
-![Figure 8B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory](images/fig-8B-7.svg)
+> ![Figure 8B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory](images/fig-8B-7.svg)
+> 
+> Figure 8B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory
+{:.figure}
 
-Figure 8B-7: Lateral view of the pelvis, showing the examining fingers just reaching the sacral promontory
-{:.figure-caption}
+> ![Figure 8B-8: The brim of the pelvis](images/fig-8B-8.svg)
+> 
+> Figure 8B-8: The brim of the pelvis
+{:.figure}
 
-![Figure 8B-8: The brim of the pelvis](images/fig-8B-8.svg)
-
-Figure 8B-8: The brim of the pelvis
-{:.figure-caption}
-
-![Figure 8B-9: The pelvic outlet](images/fig-8B-9.svg)
-
-Figure 8B-9: The pelvic outlet
-{:.figure-caption}
+> ![Figure 8B-9: The pelvic outlet](images/fig-8B-9.svg)
+> 
+> Figure 8B-9: The pelvic outlet
+{:.figure}
 
 *Step 1. The sacrum*
 

--- a/maternal-care/8c.md
+++ b/maternal-care/8c.md
@@ -21,10 +21,10 @@ When you have completed this skills chapter you should be able to:
 
 The condition of the mother, the condition of the fetus, and the progress of labour are recorded on the partogram.
 
-![Figure 8C-1: An example of a partogram](images/fig-8C-1.svg)
-
-Figure 8C-1: An example of a partogram
-{:.figure-caption}
+> ![Figure 8C-1: An example of a partogram](images/fig-8C-1.svg)
+> 
+> Figure 8C-1: An example of a partogram
+{:.figure}
 
 ## Recording the condition of the mother
 
@@ -32,10 +32,10 @@ Figure 8C-1: An example of a partogram
 
 The maternal blood pressure, pulse and temperature should be recorded on the partogram.
 
-![Figure 8C-2: Recording blood pressure, pulse, temperature and urine results on the partogram](images/fig-8C-2.svg)
-
-Figure 8C-2: Recording blood pressure, pulse, temperature and urine results on the partogram
-{:.figure-caption}
+> ![Figure 8C-2: Recording blood pressure, pulse, temperature and urine results on the partogram](images/fig-8C-2.svg)
+> 
+> Figure 8C-2: Recording blood pressure, pulse, temperature and urine results on the partogram
+{:.figure}
 
 ### B. Recording the urinary data
 
@@ -52,10 +52,10 @@ The following two observations must be recorded on the partogram:
 1.	The baseline heart rate.
 2.	The presence or absence of decelerations. If decelerations are present, you must record whether they are early or late decelerations (see figure 8C-3).
 
-![Figure 8C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram](images/fig-8C-3.svg)
-
-Figure 8C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram
-{:.figure-caption}
+> ![Figure 8C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram](images/fig-8C-3.svg)
+> 
+> Figure 8C-3: Recording the fetal heart rate pattern and the liquor findings on the partogram
+{:.figure}
 
 ### D. Recording the liquor findings
 
@@ -88,10 +88,10 @@ The length of the cervix is recorded by drawing a thick, vertical line on the sa
 
 The findings are recorded by marking an ‘O’ on the partogram (see figure 8C-4).
 
-![Figure 8C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head, and moulding on the partogram](images/fig-8C-4.svg)
-
-Figure 8C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head, and moulding on the partogram
-{:.figure-caption}
+> ![Figure 8C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head, and moulding on the partogram](images/fig-8C-4.svg)
+> 
+> Figure 8C-4: Recording the cervical dilatation, cervical length, the amount of fetal head above the brim, position of the head, and moulding on the partogram
+{:.figure}
 
 ### I. Recording the position of the fetal head
 
@@ -109,10 +109,10 @@ The duration of contractions is also recorded on the partogram. The block is sti
 
 The number of contractions occurring within 10 minutes is recorded by marking off 1 block for each contraction, e.g. 2 blocks marked off equals 2 contractions in 10 minutes, 4 blocks marked off equals 4 contractions in 10 minutes, and 5 blocks if 5 or more contractions in 10 minutes (see figure 8C-5).
 
-![Figure 8C-5: Recording the duration and frequency of contractions on the partogram](images/fig-8C-5.svg)
-
-Figure 8C-5: Recording the duration and frequency of contractions on the partogram
-{:.figure-caption}
+> ![Figure 8C-5: Recording the duration and frequency of contractions on the partogram](images/fig-8C-5.svg)
+> 
+> Figure 8C-5: Recording the duration and frequency of contractions on the partogram
+{:.figure}
 
 ### M. Recording drugs and intravenous fluid given during labour
 
@@ -126,10 +126,10 @@ In the space provided on the partogram you should record:
 6.	The rate of administration.
 7.	The amount of intravenous fluid given (after completion).
 
-![Figure 8C-6: Documenting medication, assessment, management and time on the partogram](images/fig-8C-6.svg)
-
-Figure 8C-6: Documenting medication, assessment, management and time on the partogram
-{:.figure-caption}
+> ![Figure 8C-6: Documenting medication, assessment, management and time on the partogram](images/fig-8C-6.svg)
+> 
+> Figure 8C-6: Documenting medication, assessment, management and time on the partogram
+{:.figure}
 
 ### N. Assessment and management
 
@@ -173,10 +173,10 @@ The findings must be entered on the latent phase part of the partogram, 4 hours 
 
 The X (cervical dilatation) must be moved horizontally to the right until it lies on the alert line. This will again be at 5 cm dilatation. The O (number of fifths of the head above the pelvic brim) is similarly transferred to lie on the same vertical line opposite the 2 lines on the vertical axis. The new position of the head (ROA) must be indicated on the O. The length of the cervix is recorded by a 5 mm thick black column on the base line vertically below the X and O. The fact that the membranes have been ruptured is entered in the block provided for medication/ I.V. fluids/management. A ‘C’ in the block provided for liquor indicates that the liquor is clear. The correct method of transferring the above findings from the latent to the active part of the partogram is shown in figure 8C-7. (The length of the cervix and the position of the fetal head may also be entered in the appropriate blocks provided elsewhere on the partogram).
 
-![Figure 8C-7: Information from case study 1 correctly entered onto the partogram](images/fig-8C-7.svg)
-
-Figure 8C-7: Information from case study 1 correctly entered onto the partogram
-{:.figure-caption}
+> ![Figure 8C-7: Information from case study 1 correctly entered onto the partogram](images/fig-8C-7.svg)
+> 
+> Figure 8C-7: Information from case study 1 correctly entered onto the partogram
+{:.figure}
 
 ## Case study 2
 
@@ -216,10 +216,10 @@ At the third complete examination the maternal and fetal conditions are satisfac
 
 Labour is progressing satisfactorily. This is shown by the third X having moved closer to the alert line. The head, which has rotated from the left occipito-posterior to the left occipito-anterior position, is also engaged. A spontaneous vertex delivery may be expected within an hour.
 
-![Figure 8C-8: Information from case study 2 correctly entered onto the partogram](images/fig-8C-8.svg)
-
-Figure 8C-8: Information from case study 2 correctly entered onto the partogram
-{:.figure-caption}
+> ![Figure 8C-8: Information from case study 2 correctly entered onto the partogram](images/fig-8C-8.svg)
+> 
+> Figure 8C-8: Information from case study 2 correctly entered onto the partogram
+{:.figure}
 
 ## Case study 3
 
@@ -241,7 +241,7 @@ Meconium in the liquor indicates that the fetus is at an increased risk for feta
 
 The most likely outcome is the development of cephalopelvic disproportion. On abdominal examination the head will remain 3/5 or more palpable above the pelvic brim (i.e. unengaged) and on vaginal examination there will be 3+ moulding. An urgent Caesarean section should then be performed.
 
-![Figure 8C-9: Information from case study 3 correctly entered onto the partogram](images/fig-8C-9.svg)
-
-Figure 8C-9: Information from case study 3 correctly entered onto the partogram
-{:.figure-caption}
+> ![Figure 8C-9: Information from case study 3 correctly entered onto the partogram](images/fig-8C-9.svg)
+> 
+> Figure 8C-9: Information from case study 3 correctly entered onto the partogram
+{:.figure}

--- a/maternal-care/9a.md
+++ b/maternal-care/9a.md
@@ -42,10 +42,10 @@ The midline episiotomy has the danger that it can extend into the rectum to beco
 
 The incision should only be started during a contraction when the presenting part is stretching the perineum. Doing the episiotomy too early may cause severe bleeding and will not immediately assist the delivery. The incision is started in the midline with the scissors pointed 45° away from the anus. It is usually directed to the patient’s left but can also be to the right. 2 fingers of the left hand are slipped between the perineum and the presenting part when performing a mediolateral episiotomy.
 
-![Figure 9A-1: The method of performing a left mediolateral episiotomy](images/fig-9A-1.svg)
-
-Figure 9A-1: The method of performing a left mediolateral episiotomy
-{:.figure-caption}
+> ![Figure 9A-1: The method of performing a left mediolateral episiotomy](images/fig-9A-1.svg)
+> 
+> Figure 9A-1: The method of performing a left mediolateral episiotomy
+{:.figure}
 
 ### E. Problems with episiotomies
 
@@ -78,10 +78,10 @@ Arterial bleeders may have to be temporarily clamped, while venous bleeding is e
 5.	Haemostasis must be obtained.
 6.	The needles must be handled with a pair of forceps and not by hand, and should be removed from the operating field as soon as possible.
 
-![Figure 9A-2: The method of safely handling a needle](images/fig-9A-2.svg)
-
-Figure 9A-2: The method of safely handling a needle
-{:.figure-caption}
+> ![Figure 9A-2: The method of safely handling a needle](images/fig-9A-2.svg)
+> 
+> Figure 9A-2: The method of safely handling a needle
+{:.figure}
 
 ### H. The method of suturing an episiotomy
 
@@ -91,19 +91,19 @@ Three layers have to be repaired:
 2.	The muscles.
 3.	The perineal skin.
 
-![Figure 9A-3: An episiotomy wound](images/fig-9A-3.svg)
-
-Figure 9A-3: An episiotomy wound
-{:.figure-caption}
+> ![Figure 9A-3: An episiotomy wound](images/fig-9A-3.svg)
+> 
+> Figure 9A-3: An episiotomy wound
+{:.figure}
 
 There are four important steps in the repair of an episiotomy wound.
 
 *Step 1*: Place a suture (stitch) at the apex of the incision in the vaginal epithelium. Then insert one or two more continuous sutures in the vaginal epithelium. Do not complete suturing the vaginal epithelium when the episiotomy is large or deeply cut but leave this suture and do not cut it. When placing the suture at the apex, be very careful not to prick your finger with the needle.
 
-![Figure 9A-4: Suturing the vaginal epithelium](images/fig-9A-4.svg)
-
-Figure 9A-4: Suturing the vaginal epithelium
-{:.figure-caption}
+> ![Figure 9A-4: Suturing the vaginal epithelium](images/fig-9A-4.svg)
+> 
+> Figure 9A-4: Suturing the vaginal epithelium
+{:.figure}
 
 *Step 2*: Insert interrupted sutures in the muscles. Start at the apex of the wound. The aim is to bring the muscles together firmly and to eliminate any ‘dead space’, i.e. any spaces between the muscles where blood can collect. Remember that the sutures must be inserted at 90 degrees to the line of the wound.
 
@@ -112,24 +112,24 @@ When suturing the muscles, be careful not to put the suture through the rectum. 
 1.	The remains of the hymen.
 2.	The junction of the skin and the vaginal epithelium. The skin is recognised by the darker pigmentation.
 
-![Figure 9A-5: Suturing the muscles](images/fig-9A-5.svg)
-
-Figure 9A-5: Suturing the muscles
-{:.figure-caption}
+> ![Figure 9A-5: Suturing the muscles](images/fig-9A-5.svg)
+> 
+> Figure 9A-5: Suturing the muscles
+{:.figure}
 
 *Step 3*: Return to the vaginal epithelium and complete the continuous catgut suture, ending at the junction with the skin. Do not pull the sutures tight as they only need to bring the edges of the vaginal epithelium together.
 
-![Figure 9A-6: The correct position of the skin and vaginal epithelium](images/fig-9A-6.svg)
-
-Figure 9A-6: The correct position of the skin and vaginal epithelium
-{:.figure-caption}
+> ![Figure 9A-6: The correct position of the skin and vaginal epithelium](images/fig-9A-6.svg)
+> 
+> Figure 9A-6: The correct position of the skin and vaginal epithelium
+{:.figure}
 
 *Step 4*: Use interrupted sutures with an absorbable suture material to repair the perineal skin. Mattress sutures may be used. Do not pull the sutures tight as they only need to bring the edges of the skin together. Sutures that are too tight become uncomfortable for the patient.
 
-![Figure 9A-7: The repair of the skin](images/fig-9A-7.svg)
-
-Figure 9A-7: The repair of the skin
-{:.figure-caption}
+> ![Figure 9A-7: The repair of the skin](images/fig-9A-7.svg)
+> 
+> Figure 9A-7: The repair of the skin
+{:.figure}
 
 When the suturing is complete:
 

--- a/maternal-mental-health/2.md
+++ b/maternal-mental-health/2.md
@@ -169,10 +169,10 @@ There are a number of benefits to providing mental health screening in the mater
 
 Before screening can be started, a referral system must be in place so that those women who are identified as being at risk or experiencing symptoms of mental illness can be appropriately referred to support groups, counsellors, psychiatrists, mental health nurses, social workers or other appropriate services.
 
-![Figure 2-1: Referral systems need to be in place so that women can be appropriately referred.](images/2-1.svg)
-
-Figure 2-1: Referral systems need to be in place so that women can be appropriately referred.
-{:.figure-caption}
+> ![Figure 2-1: Referral systems need to be in place so that women can be appropriately referred.](images/2-1.svg)
+> 
+> Figure 2-1: Referral systems need to be in place so that women can be appropriately referred.
+{:.figure}
 
 ### 2-18 Who should be screened?
 
@@ -221,10 +221,10 @@ If the mother chooses to fill in the questionnaire by herself, ask her which lan
 
 Some women may not be able to read and write well. A friendly way of helping the mother could be to say ‘I am here to help you if you have any problem completing the questionnaire.’
 
-![Figure 2-2: Screening should be conducted privately but you may offer to help mothers who may not be able to read and write well.](images/2-2.svg)
-
-Figure 2-2: Screening should be conducted privately but you may offer to help mothers who may not be able to read and write well.
-{:.figure-caption}
+> ![Figure 2-2: Screening should be conducted privately but you may offer to help mothers who may not be able to read and write well.](images/2-2.svg)
+> 
+> Figure 2-2: Screening should be conducted privately but you may offer to help mothers who may not be able to read and write well.
+{:.figure}
 
 ### 2-26 How can you determine whether the form has been filled in correctly?
 

--- a/maternal-mental-health/3.md
+++ b/maternal-mental-health/3.md
@@ -222,10 +222,10 @@ The diagram below illustrates different types of care appropriate for different 
 
 #### Mild distress
 
-![Figure 3-1: Talking to a trusted friend](images/3-1.svg)
-
-Figure 3-1: Talking to a trusted friend
-{:.figure-caption .keep-with-next}
+> ![Figure 3-1: Talking to a trusted friend](images/3-1.svg)
+> 
+> Figure 3-1: Talking to a trusted friend
+{:.figure .keep-with-next}
 
 **Individual support:**
 
@@ -237,10 +237,10 @@ Figure 3-1: Talking to a trusted friend
 
 #### Mild to Moderate distress
 
-![Figure 3-2: Attending a support group](images/3-2.svg)
-
-Figure 3-2: Attending a support group
-{:.figure-caption .keep-with-next}
+> ![Figure 3-2: Attending a support group](images/3-2.svg)
+> 
+> Figure 3-2: Attending a support group
+{:.figure .keep-with-next}
  
 **Group support:**
 
@@ -255,10 +255,10 @@ Figure 3-2: Attending a support group
 
 #### Severe distress
 
-![Figure 3-3: Counselling](images/3-3.svg)
-
-Figure 3-3: Counselling
-{:.figure-caption .keep-with-next}
+> ![Figure 3-3: Counselling](images/3-3.svg)
+> 
+> Figure 3-3: Counselling
+{:.figure .keep-with-next}
 
 **Medical support:**
 
@@ -390,10 +390,10 @@ To have another woman in constant attendance during birth and the weeks that fol
 
 All mothers need to be able to trust the people around them during the birthing process. The doula creates a safe environment where the mother feels protected and calm. A doula does not perform any medical tasks but can assist labour ward staff by calming and supporting mothers in labour.
 
-![Figure 3-4: A doula is a birth companion who calms and supports a mother in labour](images/3-4.svg)
-
-Figure 3-4: A doula is a birth companion who calms and supports a mother in labour
-{:.figure-caption}
+> ![Figure 3-4: A doula is a birth companion who calms and supports a mother in labour](images/3-4.svg)
+> 
+> Figure 3-4: A doula is a birth companion who calms and supports a mother in labour
+{:.figure}
 
 ### 3-28 What are the benefits of having a doula?
 

--- a/maternal-mental-health/4.md
+++ b/maternal-mental-health/4.md
@@ -107,10 +107,10 @@ Her emotional state can be influenced by:
 The following image shows the different factors which can influence a woman’s emotional state during the perinatal period. 
 {:.keep-with-next}
 
-![Figure 4-1: Factors affecting a woman's emotional state in the perinatal period](images/4-1.svg)
-
-Figure 4-1: Factors affecting a woman's emotional state in the perinatal period
-{:.figure-caption}
+> ![Figure 4-1: Factors affecting a woman's emotional state in the perinatal period](images/4-1.svg)
+> 
+> Figure 4-1: Factors affecting a woman's emotional state in the perinatal period
+{:.figure}
 
 ### 4-9 Why is understanding different backgrounds and circumstances important? 
 
@@ -351,10 +351,10 @@ Speak to someone you trust when you feel anxious, sad or stressed. Talking about
 *	Avoid people who are critical, judgemental or negative.
 {:.keep-with-next}
 
-![Figure 4-2: Speaking to a trusted colleague can help you deal with stressful situations at work and at home.](images/4-2.svg)
-
-Figure 4-2: Speaking to a trusted colleague can help you deal with stressful situations at work and at home.
-{:.figure-caption}
+> ![Figure 4-2: Speaking to a trusted colleague can help you deal with stressful situations at work and at home.](images/4-2.svg)
+> 
+> Figure 4-2: Speaking to a trusted colleague can help you deal with stressful situations at work and at home.
+{:.figure}
 
 **Take time out**
 {:.keep-with-next}
@@ -509,10 +509,10 @@ To validate someone’s feelings means to give value to her feelings, and show a
 *	Rush the appointment 
 *	Ask too many questions, give advice or judge.
 
-![Figure 4-3: Active listening empowers mothers to think about and solve their own problems.](images/4-3.svg)
-
-Figure 4-3: Active listening empowers mothers to think about and solve their own problems.
-{:.figure-caption .keep-with-next}
+> ![Figure 4-3: Active listening empowers mothers to think about and solve their own problems.](images/4-3.svg)
+> 
+> Figure 4-3: Active listening empowers mothers to think about and solve their own problems.
+{:.figure .keep-with-next}
 
 ### 4-36 When you are listening, how should you respond?
 

--- a/maternal-mental-health/5.md
+++ b/maternal-mental-health/5.md
@@ -180,10 +180,10 @@ Because refugees have been separated from their families and communities, they o
 Note
 :	“Loneliness, loss of identity, poverty and trauma are the main stressors that we see. Many refugee women have no-one to talk to, and pregnancy makes them more vulnerable.” Charlotte Mande-Ilunga: French-speaking Perinatal Mental Health Project counsellor
 
-![Figure 5-1: Loneliness, loss of identity, poverty and trauma are the main stressors refugees face.](images/5-1.svg)
-
-Figure 5-1: Loneliness, loss of identity, poverty and trauma are the main stressors refugees face.
-{:.figure-caption}
+> ![Figure 5-1: Loneliness, loss of identity, poverty and trauma are the main stressors refugees face.](images/5-1.svg)
+> 
+> Figure 5-1: Loneliness, loss of identity, poverty and trauma are the main stressors refugees face.
+{:.figure}
 
 ## Substance misuse
 
@@ -318,10 +318,10 @@ Domestic violence often occurs in a cycle.
 6.	‘Honeymoon’ phase: the quiet, violence-free period starts again and the cycle continues
 {:.keep-with-next}
 
-![Figure 5-2: The cycle of violence](images/5-2.svg)
-
-Figure 5-2: The cycle of violence
-{:.figure-caption}
+> ![Figure 5-2: The cycle of violence](images/5-2.svg)
+> 
+> Figure 5-2: The cycle of violence
+{:.figure}
 
 The cycle usually repeats itself as the woman hopes that the abuser will change and go back to the person she once knew.
 

--- a/mother-and-baby-friendly-care/4.md
+++ b/mother-and-baby-friendly-care/4.md
@@ -110,10 +110,10 @@ Because these clinics will be involved in providing follow up care to mothers wh
 
 The almost naked infant (wearing only a nappy and woollen cap) is placed between the mother’s bare breasts. If the room is cold, the infant can wear a cotton shirt, open in front. The infant is nursed upright, facing the mother with the arms and legs flexed in the frog position, under the mother’s shirt, blouse, T-shirt or dress. Keeping the infant upright helps to prevent vomiting. All mothers should be taught how to nurse their infant in the KMC position. The mother does not need to shower or wash her chest before giving KMC.
 
-![Figure 4-1: The almost naked infant is placed between the mother's bare breasts.](images/4-1.svg)
-
-Figure 4-1: The almost naked infant is placed between the mother's bare breasts.
-{:.figure-caption}
+> ![Figure 4-1: The almost naked infant is placed between the mother's bare breasts.](images/4-1.svg)
+> 
+> Figure 4-1: The almost naked infant is placed between the mother's bare breasts.
+{:.figure}
 
 ### 4-13 How is the infant kept in position?
 
@@ -127,10 +127,10 @@ It is important that the infant is kept warm and held securely. Holding the infa
 
 Special binders or carrying pouches are commercially available and can be helpful.
 
-![Figure 4-2: The infant is secured by the mother's clothing, a blanket or towel or a special pouch or carrier.](images/4-1.svg)
-
-Figure 4-2: The infant is secured by the mother's clothing, a blanket or towel or a special pouch or carrier.
-{:.figure-caption}
+> ![Figure 4-2: The infant is secured by the mother's clothing, a blanket or towel or a special pouch or carrier.](images/4-1.svg)
+> 
+> Figure 4-2: The infant is secured by the mother's clothing, a blanket or towel or a special pouch or carrier.
+{:.figure}
 
 > No special equipment is needed to give Kangaroo Mother Care.
 

--- a/newborn-care/1.md
+++ b/newborn-care/1.md
@@ -510,7 +510,7 @@ Only if the heart rate remained below 60 per minute after 60 seconds of effectiv
 
 See Figure 1-1, the important steps in basic newborn resuscitation.
 
-![Figure 1-1: The important steps in basic newborn resuscitation.](images/1-1.svg)
-
-Figure 1-1: The important steps in basic newborn resuscitation.
-{:.figure-caption}
+> ![Figure 1-1: The important steps in basic newborn resuscitation.](images/1-1.svg)
+> 
+> Figure 1-1: The important steps in basic newborn resuscitation.
+{:.figure}

--- a/newborn-care/10A.md
+++ b/newborn-care/10A.md
@@ -55,10 +55,10 @@ The result of the shake test is determined by observing the number of bubbles pr
 2. If bubbles are seen around the top of the fluid but not enough bubbles are present to completely cover the surface, then the test is *intermediate*. This result indicates that only some surfactant is present in the lungs and the infant may still develop mild hyaline membrane disease.
 3. If bubbles are present right across the surface of the fluid, then the test is *positive*. This indicates that the lungs are mature and are producing adequate amounts of surfactant. Any respiratory distress that the infant might develop is very unlikely to be due to hyaline membrane disease.
 
-![Figure 10A-1: The method of evaluating the shake test.](images/10a-1.svg)
-
-Figure 10A-1: The method of evaluating the shake test.
-{:.figure-caption}
+> ![Figure 10A-1: The method of evaluating the shake test.](images/10a-1.svg)
+> 
+> Figure 10A-1: The method of evaluating the shake test.
+{:.figure}
 
 ### 10-e Problems with the shake test
 

--- a/newborn-care/1A.md
+++ b/newborn-care/1A.md
@@ -177,10 +177,10 @@ The infant must lie supine (back down) on a firm, flat horizontal surface. A res
 
 If you pretend that you are offered a flower to smell, you would hold the flower in front of your nose, push your head slightly forward and slightly extend your neck. This is the position that you want the infant’s head and neck to be in as it keeps the upper airways open (and makes the vocal cords easier to see with a laryngoscope).
 
-![Figure 1A-1: The position of the head during mask ventilation](images/1a-1.svg)
-
-Figure 1A-1: The position of the head during mask ventilation
-{:.figure-caption}
+> ![Figure 1A-1: The position of the head during mask ventilation](images/1a-1.svg)
+> 
+> Figure 1A-1: The position of the head during mask ventilation
+{:.figure}
 
 ### 1-h Bag and mask ventilation
 
@@ -222,53 +222,45 @@ When giving bag and mask ventilation, always watch for chest movement. Squeeze t
 13. A small stethoscope
 14. A saturation monitor is very useful but not essential.
 
-![Figure 1A-2: A bag and mask for resuscitation](images/1a-2.svg)
-{:.half-page}
+> ![Figure 1A-2: A bag and mask for resuscitation](images/1a-2.svg)
+> 
+> Figure 1A-2: A bag and mask for resuscitation
+{:.figure}
 
-Figure 1A-2: A bag and mask for resuscitation
-{:.figure-caption}
+> ![Figure 1A-3: An endotracheal tube with an introducer in place](images/1a-3.svg)
+> 
+> Figure 1A-3: An endotracheal tube with an introducer in place
+{:.figure}
 
-![Figure 1A-3: An endotracheal tube with an introducer in place](images/1a-3.svg)
-{:.half-page}
+> ![Figure 1A-4: A laryngoscope with a small, straight blade](images/1a-4.svg)
+> 
+> Figure 1A-4: A laryngoscope with a small, straight blade
+{:.figure}
 
-Figure 1A-3: An endotracheal tube with an introducer in place
-{:.figure-caption}
+> ![Figure 1A-5: The blade of the laryngoscope on the tongue](images/1a-5.svg)
+> 
+> Figure 1A-5: The blade of the laryngoscope on the tongue
+{:.figure}
 
-![Figure 1A-4: A laryngoscope with a small, straight blade](images/1a-4.svg)
-{:.half-page}
+> ![Figure 1A-6: A view of the epiglottis](images/1a-6.svg)
+> 
+> Figure 1A-6: A view of the epiglottis
+{:.figure}
 
-Figure 1A-4: A laryngoscope with a small, straight blade
-{:.figure-caption}
+> ![Figure 1A-7: The laryngoscope is lifted upwards to see the vocal cords. Note that the tip of the blade is in the hollow just before the epiglottis.](images/1a-7.svg)
+> 
+> Figure 1A-7: The laryngoscope is lifted upwards to see the vocal cords. Note that the tip of the blade is in the hollow just before the epiglottis.
+{:.figure}
 
-![Figure 1A-5: The blade of the laryngoscope on the tongue](images/1a-5.svg)
-{:.half-page}
+> ![Figure 1A-8: View of the larynx.](images/1a-8.svg)
+> 
+> Figure 1A-8: View of the larynx.
+{:.figure}
 
-Figure 1A-5: The blade of the laryngoscope on the tongue
-{:.figure-caption}
-
-![Figure 1A-6: A view of the epiglottis](images/1a-6.svg)
-{:.half-page}
-
-Figure 1A-6: A view of the epiglottis
-{:.figure-caption}
-
-![Figure 1A-7: The laryngoscope is lifted upwards to see the vocal cords. Note that the tip of the blade is in the hollow just before the epiglottis.](images/1a-7.svg)
-{:.half-page}
-
-Figure 1A-7: The laryngoscope is lifted upwards to see the vocal cords. Note that the tip of the blade is in the hollow just before the epiglottis.
-{:.figure-caption}
-
-![Figure 1A-8: View of the larynx.](images/1a-8.svg)
-{:.half-page}
-
-Figure 1A-8: View of the larynx.
-{:.figure-caption}
-
-![Figure 1A-9: Introducing the endotracheal tube.](images/1a-9.svg)
-{:.half-page}
-
-Figure 1A-9: Introducing the endotracheal tube.
-{:.figure-caption}
+> ![Figure 1A-9: Introducing the endotracheal tube.](images/1a-9.svg)
+> 
+> Figure 1A-9: Introducing the endotracheal tube.
+{:.figure}
 
 The equipment must be checked daily to make certain that everything is present and in good working order.
 
@@ -307,10 +299,10 @@ An assistant ventilates the infant while you give chest compressions. The person
 
 Pressing on the sternum compresses the heart between the sternum and the spine. This squeezes blood out of the heart and into the circulation. When the sternum returns to the normal position, the heart fills again with blood. Therefore it is important that the chest be allowed time to expand fully after each compression. Repeated compression of the heart causes the blood to circulate throughout the body.
 
-![Figure 1A-10: The position of the hands when giving chest compressions.](images/1a-10.svg)
-
-Figure 1A-10: The position of the hands when giving chest compressions.
-{:.figure-caption}
+> ![Figure 1A-10: The position of the hands when giving chest compressions.](images/1a-10.svg)
+> 
+> Figure 1A-10: The position of the hands when giving chest compressions.
+{:.figure}
 
 Note
 :	The main aim of chest compressions is to perfuse the coronary arteries. This takes place when the compression on the chest is released (i.e. during diastole). Therefore, do not give chest compressions too fast.

--- a/newborn-care/2.md
+++ b/newborn-care/2.md
@@ -164,11 +164,10 @@ Likewise a low birth weight infant may weigh less than usual at delivery because
 
 > Low birth weight infants are not all born preterm.
 
-![Figure 2-1: Weight for gestational age chart](images/2-1.svg)
-{:.half-page}
-
-Figure 2-1: Weight for gestational age chart
-{:.figure-caption}
+> ![Figure 2-1: Weight for gestational age chart](images/2-1.svg)
+> 
+> Figure 2-1: Weight for gestational age chart
+{:.figure}
 
 ### 2-13 What is the value of plotting an infant’s weight for gestational age?
 

--- a/newborn-care/2A.md
+++ b/newborn-care/2A.md
@@ -222,19 +222,17 @@ The Ballard scoring method – *J Pediatr* 1991; 119: 417–423.\\
 Weight for gestational age chart – *Acta Paediatr Scand Suppl* 1985; 31: 180.\\
 Head circumference for gestational age chart – *Pediatr Res* 1978; 12: 987.
 
-![Figure 2A-1: The Ballard scoring method](images/2a-1.svg)
+> ![Figure 2A-1: The Ballard scoring method](images/2a-1.svg)
+> 
+> Figure 2A-1: The Ballard scoring method
+{:.figure}
 
-Figure 2A-1: The Ballard scoring method
-{:.figure-caption}
+> ![Figure 2A-2: Weight for gestational age chart](images/2a-2.svg)
+> 
+> Figure 2A-2: Weight for gestational age chart
+{:.figure}
 
-![Figure 2A-2: Weight for gestational age chart](images/2a-2.svg)
-{:.half-page}
-
-Figure 2A-2: Weight for gestational age chart
-{:.figure-caption}
-
-![Figure 2A-3: Head circumference for gestational age chart](images/2a-3.svg)
-{:.half-page}
-
-Figure 2A-3: Head circumference for gestational age chart
-{:.figure-caption}
+> ![Figure 2A-3: Head circumference for gestational age chart](images/2a-3.svg)
+> 
+> Figure 2A-3: Head circumference for gestational age chart
+{:.figure}

--- a/newborn-care/2A.md
+++ b/newborn-care/2A.md
@@ -225,7 +225,7 @@ Head circumference for gestational age chart – *Pediatr Res* 1978; 12: 987.
 > ![Figure 2A-1: The Ballard scoring method](images/2a-1.svg)
 > 
 > Figure 2A-1: The Ballard scoring method
-{:.figure}
+{:.figure .large}
 
 > ![Figure 2A-2: Weight for gestational age chart](images/2a-2.svg)
 > 

--- a/newborn-care/3A.md
+++ b/newborn-care/3A.md
@@ -121,7 +121,7 @@ See Figure 3A-1, a form used to record the results of the physical examination. 
 > ![Figure 3A-1: Form for recording the results of a physical examination](images/3a-1.svg)
 > 
 > Figure 3A-1: Form for recording the results of a physical examination
-{:.figure}
+{:.figure .large}
 
 ### 3-h Guidelines for a detailed examination
 
@@ -674,4 +674,4 @@ Details of the information recorded on the preschool health card vary slightly f
 > ![Figure 3A-2: The front and back of a road-to-health card](images/3a-2.svg)
 > 
 > Figure 3A-2: The front and back of a road-to-health card
-{:.figure}
+{:.figure .large}

--- a/newborn-care/3A.md
+++ b/newborn-care/3A.md
@@ -118,10 +118,10 @@ When the history has been taken and the physical examination completed, an overa
 
 See Figure 3A-1, a form used to record the results of the physical examination. It can also be used as a guideline for a basic general examination.
 
-![Figure 3A-1: Form for recording the results of a physical examination](images/3a-1.svg)
-
-Figure 3A-1: Form for recording the results of a physical examination
-{:.figure-caption}
+> ![Figure 3A-1: Form for recording the results of a physical examination](images/3a-1.svg)
+> 
+> Figure 3A-1: Form for recording the results of a physical examination
+{:.figure}
 
 ### 3-h Guidelines for a detailed examination
 
@@ -671,7 +671,7 @@ After delivery the clinic or hospital staff must enter the perinatal details ont
 
 Details of the information recorded on the preschool health card vary slightly from one region to another. Sometimes additional information is also recorded after delivery.
 
-![Figure 3A-2: The front and back of a road-to-health card](images/3a-2.svg)
-
-Figure 3A-2: The front and back of a road-to-health card
-{:.figure-caption}
+> ![Figure 3A-2: The front and back of a road-to-health card](images/3a-2.svg)
+> 
+> Figure 3A-2: The front and back of a road-to-health card
+{:.figure}

--- a/newborn-care/5A.md
+++ b/newborn-care/5A.md
@@ -293,10 +293,10 @@ Different observation charts are used in different hospitals. However, they all 
 
 See Figure 5A-1, an example of a chart used for the routine observations of sick infants.
 
-![Figure 5A-1: an example of a chart used for the routine observations of sick infants](images/5a-1.svg)
-
-Figure 5A-1: an example of a chart used for the routine observations of sick infants
-{:.figure-caption}
+> ![Figure 5A-1: an example of a chart used for the routine observations of sick infants](images/5a-1.svg)
+> 
+> Figure 5A-1: an example of a chart used for the routine observations of sick infants
+{:.figure}
 
 ## Recording fluid intake and output
 
@@ -326,7 +326,7 @@ Each type of fluid loss is recorded separately and then added up at the end of t
 
 See Figure 5A-2, an example of an intake and output chart.
 
-![Figure 5A-2: An example of an intake and output chart](images/5a-2.svg)
-
-Figure 5A-2: An example of an intake and output chart
-{:.figure-caption}
+> ![Figure 5A-2: An example of an intake and output chart](images/5a-2.svg)
+> 
+> Figure 5A-2: An example of an intake and output chart
+{:.figure}

--- a/newborn-care/8.md
+++ b/newborn-care/8.md
@@ -321,7 +321,7 @@ Give 5 mg hydrocortisone intravenously.
 
 The maternal diabetes should have been well controlled. As this infant is at very high risk of hypoglycaemia due to the poor diabetic control and high birth weight, milk feeds should have been given straight away and a 10% dextrose or Neonatalyte infusion started. Once feeds are tolerated and the reagent strip readings are normal, the infusion can gradually be slowed.
 
-![Figure 8-1: The acute management of an infant with hypoglycaemia](images/8-1.svg)
-
-Figure 8-1: The acute management of an infant with hypoglycaemia
-{:.figure-caption}
+> ![Figure 8-1: The acute management of an infant with hypoglycaemia](images/8-1.svg)
+> 
+> Figure 8-1: The acute management of an infant with hypoglycaemia
+{:.figure}

--- a/newborn-care/8A.md
+++ b/newborn-care/8A.md
@@ -41,10 +41,10 @@ Note
 
 While capillary blood is usually used, a sample of venous or arterial blood is also suitable. 
 
-![Figure 8A-1: The areas of the heel (shaded) that are usually used to obtain capillary blood](images/8a-1.svg)
-
-Figure 8A-1: The areas of the heel (shaded) that are usually used to obtain capillary blood
-{:.figure-caption}
+> ![Figure 8A-1: The areas of the heel (shaded) that are usually used to obtain capillary blood](images/8a-1.svg)
+> 
+> Figure 8A-1: The areas of the heel (shaded) that are usually used to obtain capillary blood
+{:.figure}
 
 Capillary blood is usually obtained from the infant’s heel:
 
@@ -140,54 +140,53 @@ These items should be packed and ready in a surgical tray. Remember that inserti
 6. Place a sterile towel around the umbilicus.
 7. Loosely tie a sterile tape around the base of the umbilical cord. This is done so that the tape can be quickly tied if the cut umbilical vessels start to bleed.
 
-	![Figure 8A-2: Loosely tie a tape around the base of the umbilical cord](images/8a-2.svg)
-
-	Figure 8A-2: Loosely tie a tape around the base of the umbilical cord
-	{:.figure-caption}
+	> ![Figure 8A-2: Loosely tie a tape around the base of the umbilical cord](images/8a-2.svg)
+	> 
+	> Figure 8A-2: Loosely tie a tape around the base of the umbilical cord
+	{:.figure}
 	
 8. Grasp the base of the cord between the thumb and index finger of one hand. Do not release the pressure on the base of the cord until the catheter has been inserted and the tape around the base of the cord has been firmly tied. This is very important to prevent bleeding from the cord vessels.
-
 	
-	![Figure 8A-3: Squeeze the base of the umbilical cord to prevent any possible bleeding from the umbilical vessels when they are cut.](images/8a-3.svg)
-
-	Figure 8A-3: Squeeze the base of the umbilical cord to prevent any possible bleeding from the umbilical vessels when they are cut.
-	{:.figure-caption}
+	> ![Figure 8A-3: Squeeze the base of the umbilical cord to prevent any possible bleeding from the umbilical vessels when they are cut.](images/8a-3.svg)
+	> 
+	> Figure 8A-3: Squeeze the base of the umbilical cord to prevent any possible bleeding from the umbilical vessels when they are cut.
+	{:.figure}
 	
 9. While squeezing the base of the cord, ask the assistant to hold up the cord away from the infant’s abdominal wall. Now cut the cord off about 2 cm from the skin. Immediately after cutting the umbilical cord, the scalpel blade must be dropped into a special container for ‘sharps’.
 10. On the cut end of the cord you will now see the one umbilical vein and two umbilical arteries. The umbilical vein is thin walled and situated towards the infant’s head (at 12 o’clock) while the umbilical arteries have thick walls and are situated towards the infant’s feet (at 4 and 8 o’clock).
 
-	![Figure 8A-4: The cut surface of the umbilical cord has one thin-walled vein and two thick walled arteries.](images/8a-4.svg)
-
-	Figure 8A-4: The cut surface of the umbilical cord has one thin-walled vein and two thick walled arteries.
-	{:.figure-caption}
+	> ![Figure 8A-4: The cut surface of the umbilical cord has one thin-walled vein and two thick walled arteries.](images/8a-4.svg)
+	> 
+	> Figure 8A-4: The cut surface of the umbilical cord has one thin-walled vein and two thick walled arteries.
+	{:.figure}
 
 11. Insert the tip of the saline-filled catheter into the umbilical vein. Only gentle pressure is needed to introduce the catheter. Feed about 10 cm of the catheter into the vein, when you should be able to aspirate blood.
 12. Tighten the knot of the tape around the umbilical cord to prevent bleeding from the arteries. Only now should you release your grip on the base of the umbilical cord.
 
-	![Figure 8A-5: The catheter has been inserted into the umbilical vein and the tape has been tied tightly around the base of the umbilical cord.](images/8a-5.svg)
-
-	Figure 8A-5: The catheter has been inserted into the umbilical vein and the tape has been tied tightly around the base of the umbilical cord.
-	{:.figure-caption}
+	> ![Figure 8A-5: The catheter has been inserted into the umbilical vein and the tape has been tied tightly around the base of the umbilical cord.](images/8a-5.svg)
+	> 
+	> Figure 8A-5: The catheter has been inserted into the umbilical vein and the tape has been tied tightly around the base of the umbilical cord.
+	{:.figure}
 
 13. Spray the area of skin around the umbilicus with acrylic spray (plastic skin) and allow to dry.
 14. Cut 2 lengths of strapping about 15 cm each. Fold them as shown in Figure 8A-6 and attach to the prepared skin on either side of the umbilical cord to form the ‘uprights’ of a ‘soccer goal post’.
 
-	![Figure 8A-6: Two lengths of strapping are folded as illustrated.](images/8a-6.svg)
+	> ![Figure 8A-6: Two lengths of strapping are folded as illustrated.](images/8a-6.svg)
+	> 
+	> Figure 8A-6: Two lengths of strapping are folded as illustrated.
+	{:.figure}
 
-	Figure 8A-6: Two lengths of strapping are folded as illustrated.
-	{:.figure-caption}
-
-	![Figure 8A-7: The pieces of strapping are stuck to the prepared skin on either side of the umbilical cord.](images/8a-7.svg)
-
-	Figure 8A-7: The pieces of strapping are stuck to the prepared skin on either side of the umbilical cord.
-	{:.figure-caption}
+	> ![Figure 8A-7: The pieces of strapping are stuck to the prepared skin on either side of the umbilical cord.](images/8a-7.svg)
+	> 
+	> Figure 8A-7: The pieces of strapping are stuck to the prepared skin on either side of the umbilical cord.
+	{:.figure}
 	
 15. Use a piece of strapping to fix the catheter to the ‘uprights’ as shown.
 
-	![Figure 8A-8: A piece of strapping is used to fix the catheter in place.](images/8a-8.svg)
-
-	Figure 8A-8: A piece of strapping is used to fix the catheter in place.
-	{:.figure-caption}
+	> ![Figure 8A-8: A piece of strapping is used to fix the catheter in place.](images/8a-8.svg)
+	> 
+	> Figure 8A-8: A piece of strapping is used to fix the catheter in place.
+	{:.figure}
 	
 16. The catheter is now ready to be used and can be attached to a syringe, intravenous giving set or to a 3 way tap.
 

--- a/newborn-care/9.md
+++ b/newborn-care/9.md
@@ -300,15 +300,15 @@ With phototherapy it is possible to avoid almost all exchange transfusions.
 
 *Prophylactic phototherapy* is given when the TSB is still below the phototherapy line but either the TSB is expected to increase rapidly or the infant is at an increased risk of bilirubin encephalopathy. Therefore, prophylactic phototherapy is started immediately after birth if haemolytic disease of the newborn is suspected or diagnosed. Prophylactic phototherapy in preterm infants is usually started when the TSB reaches 125 µmol/l in infants weighing less than 1250 g, at 150&nbsp;µmol/l in infants less than 1500 g, and at 200&nbsp;µmol/l in infants weighing less than 2000&nbsp;g.
 
-![Figure 9-1: Simple phototherapy guide for term infants showing the phototherapy line.](images/9-1.svg)
+> ![Figure 9-1: Simple phototherapy guide for term infants showing the phototherapy line.](images/9-1.svg)
+> 
+> Figure 9-1: Simple phototherapy guide for term infants showing the phototherapy line.
+{:.figure}
 
-Figure 9-1: Simple phototherapy guide for term infants showing the phototherapy line.
-{:.figure-caption}
-
-![Figure 9-2: Detailed phototherapy chart for infants in different birth weight and gestational age categories (e.g. 34 to 34 weeks and 6 days or 34 to less than 35 weeks). (From: A R Horn: Neonatal Medicine, University of Cape Town.) Start intensive phototherapy when the TSB is above the line according to gestation or weight.](images/9-2.svg)
-
-Figure 9-2: Detailed phototherapy chart for infants in different birth weight and gestational age categories (e.g. 34 to 34 weeks and 6 days or 34 to less than 35 weeks). (From: A R Horn: Neonatal Medicine, University of Cape Town.) Start intensive phototherapy when the TSB is above the line according to gestation or weight.
-{:.figure-caption}
+> ![Figure 9-2: Detailed phototherapy chart for infants in different birth weight and gestational age categories (e.g. 34 to 34 weeks and 6 days or 34 to less than 35 weeks). (From: A R Horn: Neonatal Medicine, University of Cape Town.) Start intensive phototherapy when the TSB is above the line according to gestation or weight.](images/9-2.svg)
+> 
+> Figure 9-2: Detailed phototherapy chart for infants in different birth weight and gestational age categories (e.g. 34 to 34 weeks and 6 days or 34 to less than 35 weeks). (From: A R Horn: Neonatal Medicine, University of Cape Town.) Start intensive phototherapy when the TSB is above the line according to gestation or weight.
+{:.figure}
 
 ### 9-26 How do you give phototherapy?
 

--- a/primary-maternal-care/1.md
+++ b/primary-maternal-care/1.md
@@ -830,22 +830,22 @@ Her next visit must be arranged at a hospital. If possible, the hospital where s
 
 A fundal height measurement midway between the symphysis pubis and the umbilicus suggests a gestational age of 16 weeks. According to her dates, the patient is 14 weeks pregnant. As the difference between these two estimations is less than 3 weeks, the duration of pregnancy as calculated from the patient’s dates must be accepted as the correct one.
 
-![Figure 1-1: The front of an antenatal record card](images/1-1.svg)
+> ![Figure 1-1: The front of an antenatal record card](images/1-1.svg)
+> 
+> Figure 1-1: The front of an antenatal record card
+{:.figure}
 
-Figure 1-1: The front of an antenatal record card
-{:.figure-caption}
+> ![Figure 1-2: The back of an antenatal record card](images/1-2.svg)
+> 
+> Figure 1-2: The back of an antenatal record card
+{:.figure}
 
-![Figure 1-2: The back of an antenatal record card](images/1-2.svg)
+> ![Figure 1-3: Clinic checklist](images/1-3.svg)
+> 
+> Figure 1-3: Clinic checklist
+{:.figure}
 
-Figure 1-2: The back of an antenatal record card
-{:.figure-caption}
-
-![Figure 1-3: Clinic checklist](images/1-3.svg)
-
-Figure 1-3: Clinic checklist
-{:.figure-caption}
-
-![Figure 1-4: Back page of clinic checklist](images/1-4.svg)
-
-Figure 1-4: Back page of clinic checklist
-{:.figure-caption}
+> ![Figure 1-4: Back page of clinic checklist](images/1-4.svg)
+> 
+> Figure 1-4: Back page of clinic checklist
+{:.figure}

--- a/primary-maternal-care/1A.md
+++ b/primary-maternal-care/1A.md
@@ -53,10 +53,10 @@ A retained placenta or postpartum haemorrhage in previous pregnancies should be 
 
 All these findings should be recorded briefly on the antenatal clinic record.
 
-![Figure 1A-1: Recording past obstetric history](images/1A-1.svg)
-
-Figure 1A-1: Recording past obstetric history
-{:.figure-caption}
+> ![Figure 1A-1: Recording past obstetric history](images/1A-1.svg)
+> 
+> Figure 1A-1: Recording past obstetric history
+{:.figure}
 
 ### C Medical history
 

--- a/primary-maternal-care/1B.md
+++ b/primary-maternal-care/1B.md
@@ -75,20 +75,20 @@ The symphysis-fundus height should be measured as follows:
 
 Having determined the height of the fundus, you need to assess whether the height of the fundus corresponds to the patient’s dates, and to the size of the fetus. From 18 weeks, the S-F height must be plotted on the SF growth curve to determine the gestational age. This method is, therefore, only used once the fundal height has reached 18 weeks. In other words when the S-F height has reached two fingers width under the umbilicus.
 
-![Figure 1B-1: Determining the fundal height](images/1B-1.svg)
+> ![Figure 1B-1: Determining the fundal height](images/1B-1.svg)
+> 
+> Figure 1B-1: Determining the fundal height
+{:.figure}
 
-Figure 1B-1: Determining the fundal height
-{:.figure-caption}
+> ![Figure 1B-2: Determining the uterine size before 24 weeks](images/1B-2.svg)
+> 
+> Figure 1B-2: Determining the uterine size before 24 weeks
+{:.figure}
 
-![Figure 1B-2: Determining the uterine size before 24 weeks](images/1B-2.svg)
-
-Figure 1B-2: Determining the uterine size before 24 weeks
-{:.figure-caption}
-
-![Figure 1B-3: Measuring the symphysis-fundus height](images/1B-3.svg)
-
-Figure 1B-3: Measuring the symphysis-fundus height
-{:.figure-caption}
+> ![Figure 1B-3: Measuring the symphysis-fundus height](images/1B-3.svg)
+> 
+> Figure 1B-3: Measuring the symphysis-fundus height
+{:.figure}
 
 ### G Palpation of the fetus
 
@@ -113,10 +113,10 @@ There are 4 specific steps for palpating the fetus. These are performed systemat
 3.	**Third step**. The examiner grasps the lower portion of the abdomen, just above the symphysis pubis, between the thumb and fingers of one hand. The objective is to feel for the presenting part of the fetus and to decide whether the presenting part is loose above the pelvis or fixed in the pelvis. If the head is loose above the pelvis, it can be easily moved and balloted. The head and breech are differentiated in the same way as in the first step.
 4.	**Fourth step**. The objective of the step is to determine the amount of head palpable above the pelvic brim, if there is a cephalic presentation. The examiner faces the patient’s feet, and with the tips of the middle 3 fingers palpates deeply in the pelvic inlet. In this way the head can usually be readily palpated, unless it is already deeply in the pelvis. The amount of the head palpable above the pelvic brim can also be determined.
 
-![Figure 1B-4: The 4 steps in palpating the fetus](images/1B-4.svg)
-
-Figure 1B-4: The 4 steps in palpating the fetus
-{:.figure-caption}
+> ![Figure 1B-4: The 4 steps in palpating the fetus](images/1B-4.svg)
+> 
+> Figure 1B-4: The 4 steps in palpating the fetus
+{:.figure}
 
 ### I Amount of head palpable above pelvis
 
@@ -128,10 +128,10 @@ The amount of head is assessed by feeling how many fifths of the head are palpab
 4.	2/5 of the head palpable means that most of the head is below the pelvic brim, and on doing the deep pelvic grip, your fingers only splay outwards from the fetal neck to the pelvic brim.
 5.	1/5 of the head palpable means that only the tip of the fetal head can be felt above the pelvic brim.
 
-![Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/1B-5.svg)
-
-Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis
-{:.figure-caption}
+> ![Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis](images/1B-5.svg)
+> 
+> Figure 1B-5: An accurate method of determining the amount of head palpable above the brim of the pelvis
+{:.figure}
 
 ### J Special points about the palpation of the fetus
 
@@ -186,10 +186,10 @@ If there is a reason for the patient to count fetal movements and to record them
 	*	Between 11:00 and 12:00 on 4th July the fetus moved 9 times.
 	*	Between 08:00 and 09:00 on 5th July the fetus moved 3 times.
 
-![Figure 1B-6: An example of fetal movements recorded on a fetal movements chart](images/1B-6.svg)
-
-Figure 1B-6: An example of fetal movements recorded on a fetal movements chart
-{:.figure-caption}
+> ![Figure 1B-6: An example of fetal movements recorded on a fetal movements chart](images/1B-6.svg)
+> 
+> Figure 1B-6: An example of fetal movements recorded on a fetal movements chart
+{:.figure}
 
 All the movements should be recorded. Therefore, every time the fetus moves, the patient must make a tick on the chart. The time and day should be marked on the chart. If the patient is illiterate, the nurse giving her the chart can fill in the day (and times if the chart is to be used more than once a day). It is important to explain to the patient exactly how to use the chart. Remember that a patient who is resting can easily fall asleep and, therefore, miss fetal movements.
 

--- a/primary-maternal-care/1D.md
+++ b/primary-maternal-care/1D.md
@@ -110,7 +110,7 @@ Note
 
 If it cannot be decided whether clumping of particles is present or not, a sample of the patient’s blood must be sent to the laboratory for a VDRL test. The patient must be seen again as soon as the results are available so that the correct management can be given. If the patient cannot come back for the result or if it is not possible to get a laboratory VDRL, start treatment immediately.
 
-![Figure 1D-1: Examples of positive and negative tests](images/1D-1.svg)
-
-Figure 1D-1: Examples of positive and negative tests
-{:.figure-caption}
+> ![Figure 1D-1: Examples of positive and negative tests](images/1D-1.svg)
+> 
+> Figure 1D-1: Examples of positive and negative tests
+{:.figure}

--- a/primary-maternal-care/1E.md
+++ b/primary-maternal-care/1E.md
@@ -72,17 +72,17 @@ The test is a specific test for HIV and will become positive when there are anti
 2.	If both the first rapid test and the confirmatory (second) test are positive, it is accepted that the patient is HIV positive. Circle ‘Yes’ for the test accepted and again ‘Yes’ for precautions.
 3.	If, after counselling, the patient decides not to have an HIV test, test accepted ‘No’ must be circled as the test was not done. Therefore there is no result.
 
-![Figure 1E-1: Recording of a negative HIV test on the antenatal card](images/1E-1.svg)
+> ![Figure 1E-1: Recording of a negative HIV test on the antenatal card](images/1E-1.svg)
+> 
+> Figure 1E-1: Recording of a negative HIV test on the antenatal card
+{:.figure}
 
-Figure 1E-1: Recording of a negative HIV test on the antenatal card
-{:.figure-caption}
+> ![Figure 1E-2: Recording of a positive HIV test on the antenatal card](images/1E-2.svg)
+> 
+> Figure 1E-2: Recording of a positive HIV test on the antenatal card
+{:.figure}
 
-![Figure 1E-2: Recording of a positive HIV test on the antenatal card](images/1E-2.svg)
-
-Figure 1E-2: Recording of a positive HIV test on the antenatal card
-{:.figure-caption}
-
-![Figure 1E-3: Recording that the patient decided not to be tested for HIV](images/1E-3.svg)
-
-Figure 1E-3: Recording that the patient decided not to be tested for HIV
-{:.figure-caption}
+> ![Figure 1E-3: Recording that the patient decided not to be tested for HIV](images/1E-3.svg)
+> 
+> Figure 1E-3: Recording that the patient decided not to be tested for HIV
+{:.figure}

--- a/primary-maternal-care/2.md
+++ b/primary-maternal-care/2.md
@@ -145,25 +145,25 @@ If Doppler measurement is not available, the patient must be managed as given in
 4.	If there are decreased or few fetal movements, the patient should be managed as described in sections 2-25 and 2-26.
 5.	When there is severe intra-uterine growth restriction, the patient must be referred to a level 2 or 3 hospital for further management.
 
-![Figure 2-1: The symphysis-fundus growth chart](images/2-1.svg)
+> ![Figure 2-1: The symphysis-fundus growth chart](images/2-1.svg)
+> 
+> Figure 2-1: The symphysis-fundus growth chart
+{:.figure}
 
-Figure 2-1: The symphysis-fundus growth chart
-{:.figure-caption}
+> ![Figure 2-2: One measurement below the 10th centile](images/2-2.svg)
+> 
+> Figure 2-2: One measurement below the 10th centile
+{:.figure}
 
-![Figure 2-2: One measurement below the 10th centile](images/2-2.svg)
+> ![Figure 2-3: Three successive measurements that remain the same](images/2-3.svg)
+> 
+> Figure 2-3: Three successive measurements that remain the same
+{:.figure}
 
-Figure 2-2: One measurement below the 10th centile
-{:.figure-caption}
-
-![Figure 2-3: Three successive measurements that remain the same](images/2-3.svg)
-
-Figure 2-3: Three successive measurements that remain the same
-{:.figure-caption}
-
-![Figure 2-4: A measurement less than that recorded 2 visits before](images/2-4.svg)
-
-Figure 2-4: A measurement less than that recorded 2 visits before
-{:.figure-caption}
+> ![Figure 2-4: A measurement less than that recorded 2 visits before](images/2-4.svg)
+> 
+> Figure 2-4: A measurement less than that recorded 2 visits before
+{:.figure}
 
 ## Fetal movements
 
@@ -299,7 +299,7 @@ If the fetal movement count remains less than half the previous count, the patie
 
 Fetal movements should be counted for a full 6 hours. If the fetus moves fewer than 4 times, there is a high chance that the fetus is distressed. A doctor must now examine the patient and decide whether the fetus should be delivered and what would be the safest method of delivery.
 
-![Figure 2-5: The management of a patient with decreased fetal movements](images/2-5.svg)
-
-Figure 2-5: The management of a patient with decreased fetal movements
-{:.figure-caption}
+> ![Figure 2-5: The management of a patient with decreased fetal movements](images/2-5.svg)
+> 
+> Figure 2-5: The management of a patient with decreased fetal movements
+{:.figure}

--- a/primary-maternal-care/2A.md
+++ b/primary-maternal-care/2A.md
@@ -35,10 +35,10 @@ The following items should be recorded on the back of the antenatal card every t
 
 The symphysis-fundus (SF) height and the patient’s weight are recorded on the antenatal graph while the other information is recorded in the spaces provided.
 
-![Figure 2A-1: The back of the antenatal card](images/2A-1.svg)
-
-Figure 2A-1: The back of the antenatal card
-{:.figure-caption}
+> ![Figure 2A-1: The back of the antenatal card](images/2A-1.svg)
+> 
+> Figure 2A-1: The back of the antenatal card
+{:.figure}
 
 ### B The significance of the lines on the graph
 
@@ -46,10 +46,10 @@ There are 3 oblique lines on the antenatal graph:
 
 The 3 lines represent the normal increase in the symphysis-fundus height or SF height (i.e. a centile growth chart of fundal height). The solid line in the centre is the 50th centile or average growth line. The dotted lines above and below this represent the 90th and 10th centiles respectively (i.e. the upper and lower limits of normal fundal growth).
 
-![Figure 2A-2: A SF height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th](images/2A-2.svg)
-
-Figure 2A-2: A SF height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th
-{:.figure-caption}
+> ![Figure 2A-2: A SF height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th](images/2A-2.svg)
+> 
+> Figure 2A-2: A SF height measurement of 21 cm at a gestational age of 24 weeks is plotted on July 27th
+{:.figure}
 
 ### C Plotting the symphysis-fundus height for the first time when the patient is sure of the date of her last menstrual period
 
@@ -68,15 +68,15 @@ Figure 2A-2: A SF height measurement of 21 cm at a gestational age of 24 weeks i
 3.	The method whereby the gestational age was determined must now be ticked in the appropriate block at the top left-hand corner of the chart. In this case ‘SF-measurement’ should be ticked.
 4.	The fundal growth must be carefully recorded at the following visits. If little or no growth occurs in the next 4 weeks, the diagnosis of intra-uterine growth restriction must be made. If excessive growth occurs, multiple pregnancy must be excluded. Normal growth with the SF-height between the 90th and 10th centiles confirms a normal growing singleton pregnancy.
 
-![Figure 2A-3: Recording the SF height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4th October.](images/2A-3.svg)
+> ![Figure 2A-3: Recording the SF height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4th October.](images/2A-3.svg)
+> 
+> Figure 2A-3: Recording the SF height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4th October.
+{:.figure}
 
-Figure 2A-3: Recording the SF height of 27 cm on the 50th centile when a patient could not remember the date of her last menstrual period. The patient attended the antenatal clinic on 4th October.
-{:.figure-caption}
-
-![Figure 2A-4: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the S-F height measurement is 25 cm.](images/2A-4.svg)
-
-Figure 2A-4: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the S-F height measurement is 25 cm.
-{:.figure-caption}
+> ![Figure 2A-4: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the S-F height measurement is 25 cm.](images/2A-4.svg)
+> 
+> Figure 2A-4: A patient’s gestational age, according to her last menstrual period, is 31 weeks and the S-F height measurement is 25 cm.
+{:.figure}
 
 ### E The first recording of the SF height when the duration of pregnancy, as determined by her last normal menstrual period, differs from that determined by the SF height by 4 or more weeks.
 
@@ -85,10 +85,10 @@ Figure 2A-4: A patient’s gestational age, according to her last menstrual peri
 3.	The method by which the gestational age is estimated must be recorded in the box at the top left-hand corner of the growth chart. In this case a tick should be made opposite ‘SF measurement’.
 4.	The fundal growth must be carefully recorded at the following visits. If little or no growth occurs in the next 4 weeks, the diagnosis of intra-uterine growth restriction must be made. If excessive growth occurs, multiple pregnancy must be excluded. Normal growth with the SF-height between the 90th and 10th centiles confirms a normal growing singleton pregnancy. This information also confirms that using the SF-height to determine gestational age was correct.
 
-![Figure 2A-5: A patient’s SF height measurement is 30 cm, 4 weeks after her last visit. Four weeks later the SF height is 32 cm.](images/2A-5.svg)
-
-Figure 2A-5: A patient’s SF height measurement is 30 cm, 4 weeks after her last visit. Four weeks later the SF height is 32 cm.
-{:.figure-caption}
+> ![Figure 2A-5: A patient’s SF height measurement is 30 cm, 4 weeks after her last visit. Four weeks later the SF height is 32 cm.](images/2A-5.svg)
+> 
+> Figure 2A-5: A patient’s SF height measurement is 30 cm, 4 weeks after her last visit. Four weeks later the SF height is 32 cm.
+{:.figure}
 
 ### F Plotting the symphysis-fundus height at subsequent antenatal visits
 
@@ -102,7 +102,7 @@ From 34 weeks gestation onwards the lie and the presenting part must be determin
 
 A space is provided on the antenatal card for brief notes. A block is also provided for a problem list. Few notes are needed and usually there are no notes in patients who are assessed as being low risk with normal pregnancies.
 
-![Figure 2A-6: A problem list with short notes](images/2A-6.svg)
-
-Figure 2A-6: A problem list with short notes
-{:.figure-caption}
+> ![Figure 2A-6: A problem list with short notes](images/2A-6.svg)
+> 
+> Figure 2A-6: A problem list with short notes
+{:.figure}

--- a/primary-maternal-care/4.md
+++ b/primary-maternal-care/4.md
@@ -355,7 +355,7 @@ Trichomonas vaginalis. Therefore, if no organisms were identified on the cervica
 
 A single dose of 2 g metronidazole (Flagyl) is given orally to both the patient and her partner. Both must be warned against drinking alcohol for a few days after taking metronidazole.
 
-![Figure 4-1: Flow diagram: Initial management of a patient with vaginal bleeding](images/4-1.svg)
-
-Figure 4-1: Flow diagram: Initial management of a patient with vaginal bleeding
-{:.figure-caption}
+> ![Figure 4-1: Flow diagram: Initial management of a patient with vaginal bleeding](images/4-1.svg)
+> 
+> Figure 4-1: Flow diagram: Initial management of a patient with vaginal bleeding
+{:.figure}

--- a/primary-maternal-care/6.md
+++ b/primary-maternal-care/6.md
@@ -223,10 +223,10 @@ If the patient and her infant are both well, they are referred to their local ma
 3.	Blood must be taken from the infant for a DNA PCR test and an appointment made so that the infant’s result can be obtained and further management planned. The DNA PCR will determine whether the infant is HIV infected.
 4.	The essential postpartum care (EPOC) card (Figure 6-1) for the 6 weeks visit could now be completed.
 
-![Figure 6-1: The essential postpartum care card](images/6-1.svg)
-
-Figure 6-1: The essential postpartum care card
-{:.figure-caption}
+> ![Figure 6-1: The essential postpartum care card](images/6-1.svg)
+> 
+> Figure 6-1: The essential postpartum care card
+{:.figure}
 
 ## Puerperal pyrexia
 

--- a/primary-maternal-care/7.md
+++ b/primary-maternal-care/7.md
@@ -195,10 +195,10 @@ Nausea and even vomiting due to irritation of the lining of the stomach.
 1.	The tablets should be taken with meals. Although less iron will be absorbed, the side effects will be less.
 2.	If the patient continues to complain of side effects, she should be given 300&nbsp;mg ferrous gluconate tablets instead. They cause fewer side effects than ferrous sulphate tablets.
 
-![Figure 7-1: Flow diagram: The management of a patient with iron-deficiency anaemia in pregnancy](images/7-1.svg)
-
-Figure 7-1: Flow diagram: The management of a patient with iron-deficiency anaemia in pregnancy
-{:.figure-caption}
+> ![Figure 7-1: Flow diagram: The management of a patient with iron-deficiency anaemia in pregnancy](images/7-1.svg)
+> 
+> Figure 7-1: Flow diagram: The management of a patient with iron-deficiency anaemia in pregnancy
+{:.figure}
 
 ## Heart valve disease in pregnancy and the puerperium
 
@@ -308,10 +308,10 @@ The patient must have nothing to eat or drink (except water) from midnight. At 0
 1.	A fasting blood glucose result of less than 6 mmol/l and a 2 hour result of less than 8 mmol/l are normal. These patients can be followed up as intermediate risk patients.
 2.	A fasting blood glucose result of 6 mmol/l or more and/or a 2 hour result of 8 mmol/l or more are abnormal. These patients must be admitted to hospital so that they can have their blood glucose concentration controlled.
 
-![Figure 7-2: Flow diagram: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy.](images/7-2.svg)
-
-Figure 7-2: Flow diagram: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy.
-{:.figure-caption}
+> ![Figure 7-2: Flow diagram: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy.](images/7-2.svg)
+> 
+> Figure 7-2: Flow diagram: The management of a patient with glycosuria who has a random blood glucose concentration measured in pregnancy.
+{:.figure}
 
 ## HIV infection and AIDS in pregnancy
 

--- a/primary-newborn-care/5.md
+++ b/primary-newborn-care/5.md
@@ -187,10 +187,10 @@ Whenever the TSB is above the normal range and approaches dangerous levels, or i
 
 See Figure 5-1 for a phototherapy chart showing the phototherapy line for term infants.
 
-![Figure 5-1: Phototherapy chart showing the phototherapy line for term infants.](images/5-1.svg)
-
-Figure 5-1: Phototherapy chart showing the phototherapy line for term infants.
-{:.figure-caption}
+> ![Figure 5-1: Phototherapy chart showing the phototherapy line for term infants.](images/5-1.svg)
+> 
+> Figure 5-1: Phototherapy chart showing the phototherapy line for term infants.
+{:.figure}
 
 *Prophylactic phototherapy* is given when the TSB is still below the phototherapy line, but either the TSB is expected to increase rapidly or the infant is at an increased risk of bilirubin encephalopathy. Therefore, prophylactic phototherapy is started immediately after birth if haemolytic disease of the newborn is suspected or diagnosed. Prophylactic phototherapy is often given to preterm infants when their TSB gets near the phototherapy line.
 


### PR DESCRIPTION
This PR changes the way we handle figures. It address issue #47 by using print-specific CSS to handle image placement. The challenge was keeping images and their captions together when we can't wrap them in a `<figure>` element (which won't validate in EPUB2). So we use a `<blockquote>` element with a `.figure` class instead. We can then control placement by floating the `<blockquote>`.

We will need to check every book's PDF output to adjust image sizes, and in some cases overriding the floats, to suit the new system. These classes can be used on the `blockquote` for this:
- `.small` reduces the image height
- `.large` fills the width and most of a printed page
- `.fixed` keeps the figure in its place in the text flow, and will not float it to the top or bottom of a page. For instance, when an image must appear in a step-by-step list of instructions.
